### PR TITLE
fix: ensure replacement package is installed

### DIFF
--- a/src/DependencyRewriterPlugin.php
+++ b/src/DependencyRewriterPlugin.php
@@ -207,7 +207,7 @@ class DependencyRewriterPlugin implements EventSubscriberInterface, PluginInterf
             $version
         ), IOInterface::VERBOSE);
 
-        $this->updatePackageFromReplacement($package, $replacementPackage);
+        $this->replacePackageInOperation($replacementPackage, $operation);
     }
 
     /**
@@ -313,11 +313,13 @@ class DependencyRewriterPlugin implements EventSubscriberInterface, PluginInterf
         }
     }
 
-    private function updatePackageFromReplacement(PackageInterface $original, PackageInterface $replacement)
+    private function replacePackageInOperation(PackageInterface $replacement, Operation\OperationInterface $operation)
     {
-        $this->updateProperty($original, 'name', $replacement->getName());
-        $this->updateProperty($original, 'prettyName', $replacement->getPrettyName());
-        $original->replaceVersion($replacement->getVersion(), $replacement->getPrettyVersion());
+        $this->updateProperty(
+            $operation,
+            $operation instanceof Operation\UpdateOperation ? 'targetPackage' : 'package',
+            $replacement
+        );
     }
 
     /**


### PR DESCRIPTION
|    Q        |   A
|------------ | ------
| Bugfix      | yes
| BC Break    | no
| New Feature | no
| RFC         | no

### Description

In testing, we discovered that while composer reports installing Laminas packages for nested dependencies, the actual packages installed were ZF packages. (Determined by examining the contents of the vendor directory.)

The solution was to update the `OperationInterface` with the replacement package found via the repository manager, instead of updating the package with the desired name. Replacing the package instance in the operation ensures that the actual package is installed.

One note: packages slip-streamed in this way do not return meaningful information via `composer why`. I am not certain there is a way to make that happen.