### PR TITLE
Feature for composer 2.0 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 /laminas-mkdoc-theme/
 /.phpunit.result.cache
 /composer.lock
+
+# Integration testings
+integration/**/vendor/
+integration/**/composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,47 +8,71 @@ env:
   global:
     - COMPOSER_ARGS="--no-interaction"
     - COVERAGE_DEPS="php-coveralls/php-coveralls"
-    - NO_TEST_DEPS="phpunit/phpunit webimpress/coding-standard"
+    - TEST_DEPS="phpunit/phpunit:^8.5 webimpress/coding-standard"
+    - COMPAT_DEPS="dealerdirect/phpcodesniffer-composer-installer"
+    - COMPOSER_VERSION=1
 
 matrix:
   include:
     - php: 5.6
       env:
-        - COMPAT_VERSION=5.6
+        - NO_TEST=1
+        - COMPAT=1
+    - php: 5.6
+      env:
+        - NO_TEST=1
+        - COMPOSER_VERSION=2
+    - php: 7.0
+      env:
         - NO_TEST=1
     - php: 7.0
       env:
-        - COMPAT_VERSION=7.0
+        - NO_TEST=1
+        - COMPOSER_VERSION=2
+    - php: 7.1
+      env:
         - NO_TEST=1
     - php: 7.1
       env:
-        - COMPAT_VERSION=7.1
         - NO_TEST=1
+        - COMPOSER_VERSION=2
     - php: 7.2
       env:
         - TEST_COVERAGE=true
-        - COMPAT_VERSION=7.2
+    - php: 7.2
+      env:
+        - COMPOSER_VERSION=2
     - php: 7.3
       env:
-        - COMPAT_VERSION=7.3
         - CS_CHECK=1
+    - php: 7.3
+      env:
+        - COMPOSER_VERSION=2
+    - php: 7.4
     - php: 7.4
       env:
-        - COMPAT_VERSION=7.4
+        - COMPOSER_VERSION=2
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
 
 install:
-  - if [[ $NO_TEST == '1' ]]; then travis_retry composer remove --dev $COMPOSER_ARGS $NO_TEST_DEPS ; fi
+  - composer self-update --${COMPOSER_VERSION}
   - travis_retry composer install $COMPOSER_ARGS
+  - if [[ $NO_TEST != '1' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $TEST_DEPS ; fi
+  - if [[ $CS_CHECK == '1' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $TEST_DEPS ; fi
+  - if [[ $COMPAT == '1' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $COMPAT_DEPS ; fi
   - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $COVERAGE_DEPS ; fi
   - stty cols 120 && composer show
 
 script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then composer test-coverage ; else if [[ $NO_TEST != '1' ]]; then  composer test ; fi ; fi
-  - if [[ $COMPAT_VERSION != '0' ]]; then composer cs-check -- -p src --standard=PHPCompatibility --runtime-set testVersion $COMPAT_VERSION ; fi
+  - if [[ $COMPAT == '1' ]]; then composer cs-check -- -p src --standard=PHPCompatibility --runtime-set testVersion 5.6- ; fi
   - if [[ $CS_CHECK == '1' ]]; then composer cs-check ; fi
+  # Copy plugin to /tmp so we can use it in integration tests
+  - rsync -avr --exclude integration/ --exclude vendor/ --exclude .git/ --exclude test/ . /tmp/laminas-dependency-plugin
+  # Execute integration tests
+  - bash integration-tests.sh
 
 after_script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then vendor/bin/php-coveralls -v ; fi

--- a/composer.json
+++ b/composer.json
@@ -8,15 +8,13 @@
     },
     "require": {
         "php": "^5.6 || ^7.0",
-        "composer-plugin-api": "^1.1"
+        "composer-plugin-api": "^1.1 || ^2.0"
     },
     "require-dev": {
-        "composer/composer": "^1.9",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
+        "composer/composer": "^1.9 || ^2.0@dev",
+        "mikey179/vfsstream": "^1.6",
         "phpcompatibility/php-compatibility": "^9.3",
-        "phpunit/phpunit": "^8.4",
-        "roave/security-advisories": "dev-master",
-        "webimpress/coding-standard": "^1.0"
+        "roave/security-advisories": "dev-master"
     },
     "autoload": {
         "psr-4": {

--- a/docs/decisions/interactive-mode-over-slipstreaming.md
+++ b/docs/decisions/interactive-mode-over-slipstreaming.md
@@ -1,0 +1,33 @@
+# Interactive mode over slipstreaming
+
+## Status
+
+accepted
+
+## Context
+
+With `composer` in v2.0, slipstreaming into the installation flow of composer does not work anymore. It is not possible to change the packages to be installed, why the initial method of this package does not work anymore.
+
+## Decision
+
+We change the way how this package interacts with projects. The project lets install any package but gathers, which of these have to be replaced with laminas packages.
+
+After composer finishes with dumping the autoloader, this plugin asks the user (in case there were packages installed which had to be replaced) if he wants to replace zendframework packages.
+
+The default answer is "yes" (in case, `composer install` was called with `--no-interaction`). 
+
+If the answer is "yes", the following flow is executed:
+
+1. Add laminas replacements to `composer.json` (with the locked version of the currently installed zend pendant)
+2. Update `composer.lock` (which uninstalls zend and installs laminas packages)
+3. Add laminas replacements to `composer.json` (with previous constraint of that package which required the zendframework package)
+4. Update `composer.lock` (with `composer update --lock`) to synchronize `composer.lock` with `composer.json`
+
+## Consequences
+
+The user now has to interact with this plugin. We are not auto-replacing zend-packgages anymore.
+This takes some more i/o as we have to write the `composer.json` and `composer.lock` multiple times.
+
+This only happens once for the project OR if you add a non-migrated 3rd-party library, which contains not already replaced zend packages.
+
+If the dependency is added to `composer.json`, there is no guarantee if the user will need the package replacement for upcoming releases of the 3rd party library. This is why we need to keep track on why a laminas replacement was added to the `composer.json`.

--- a/docs/decisions/removing-unit-testing-dev-dependencies.md
+++ b/docs/decisions/removing-unit-testing-dev-dependencies.md
@@ -1,0 +1,21 @@
+# Removing unit-testing dev-dependencies
+
+## Status
+
+proposed
+
+## Context
+
+With `composer` in v2.0, a removal of packages without existing `composer.lock` is not allowed.
+
+```
+Cannot update only a partial set of packages without a lock file present.
+```
+
+## Decision
+
+We remove the dev-dependencies for unit-testing by default and require them in travis builds.
+
+## Consequences
+
+Every contributor has to manually add the dependencies if he wants to execute unit tests.

--- a/integration-tests.sh
+++ b/integration-tests.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+INTEGRATION_TESTS_BY_TYPE_DIRECTORY="$PWD/integration"
+
+EXIT_CODE=0
+
+for INTEGRATION_TESTS_DIRECTORY in $(find $INTEGRATION_TESTS_BY_TYPE_DIRECTORY -maxdepth 1 -mindepth 1 -type d); do
+
+    echo "Running $(basename $INTEGRATION_TESTS_DIRECTORY) integration tests"
+
+    for INTEGRATION_TEST_DIRECTORY in $(find $INTEGRATION_TESTS_DIRECTORY -maxdepth 1 -mindepth 1 -type d); do
+
+        echo "> Running $(basename $INTEGRATION_TEST_DIRECTORY) integration test"
+        COMPOSER_SCRIPT=$INTEGRATION_TESTS_DIRECTORY/composer.sh
+
+        # If there is an integration test specific composer.sh, use that!
+        if [ -e "$INTEGRATION_TEST_DIRECTORY/composer.sh" ]; then
+            COMPOSER_SCRIPT=$INTEGRATION_TEST_DIRECTORY/composer.sh;
+        fi
+
+        bash $COMPOSER_SCRIPT $INTEGRATION_TEST_DIRECTORY && diff $INTEGRATION_TEST_DIRECTORY/composer.json $INTEGRATION_TEST_DIRECTORY/composer.json.out
+
+        if [ "$?" -ne 0 ]; then
+            EXIT_CODE=1
+        fi
+    done
+done
+
+exit $EXIT_CODE

--- a/integration/installs/composer.sh
+++ b/integration/installs/composer.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+composer install --no-interaction --working-dir=$1
+composer validate --no-check-all --working-dir=$1

--- a/integration/installs/dev-and-non-dev-mixed-dependencies/README.md
+++ b/integration/installs/dev-and-non-dev-mixed-dependencies/README.md
@@ -1,0 +1,4 @@
+# laminas/project-with-mixed-dependencies-on-the-same-package
+
+This package depends on both a `require` and a `dev-require` package.
+As at least one `require` package is present, the dependency plugin has to put the `laminas-mvc` dependency to the `require` dependencies.

--- a/integration/installs/dev-and-non-dev-mixed-dependencies/composer.json
+++ b/integration/installs/dev-and-non-dev-mixed-dependencies/composer.json
@@ -1,0 +1,46 @@
+{
+    "name": "laminas/project-with-mixed-dependencies-on-the-same-package",
+    "license": "BSD-3-Clause",
+    "description": "Test project to integration test laminas-dependency-plugin",
+    "require": {
+        "foo/bar": "^1.0",
+        "laminas/laminas-dependency-plugin": "*",
+        "psr/log": "^1.0"
+    },
+    "require-dev": {
+        "bar/baz": "^1.0"
+    },
+    "config": {
+        "sort-packages": true
+    },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "/tmp/laminas-dependency-plugin"
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "foo/bar",
+                "version": "1.0",
+                "type": "metapackage",
+                "require": {
+                    "zendframework/zend-mvc": "^3.1"
+                }
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "bar/baz",
+                "version": "1.0",
+                "type": "metapackage",
+                "require": {
+                    "zendframework/zend-mvc": "^2.7 || ^3.0"
+                }
+            }
+        }
+    ],
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/integration/installs/dev-and-non-dev-mixed-dependencies/composer.json.out
+++ b/integration/installs/dev-and-non-dev-mixed-dependencies/composer.json.out
@@ -1,0 +1,59 @@
+{
+    "name": "laminas/project-with-mixed-dependencies-on-the-same-package",
+    "license": "BSD-3-Clause",
+    "description": "Test project to integration test laminas-dependency-plugin",
+    "require": {
+        "foo/bar": "^1.0",
+        "laminas/laminas-dependency-plugin": "*",
+        "laminas/laminas-mvc": "^2.7 || ^3.0"
+        "psr/log": "^1.0"
+    },
+    "require-dev": {
+        "bar/baz": "^1.0"
+    },
+    "config": {
+        "sort-packages": true
+    },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "/tmp/laminas-dependency-plugin"
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "foo/bar",
+                "version": "1.0",
+                "type": "metapackage",
+                "require": {
+                    "zendframework/zend-mvc": "^3.1"
+                }
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "bar/baz",
+                "version": "1.0",
+                "type": "metapackage",
+                "require": {
+                    "zendframework/zend-mvc": "^2.7 || ^3.0"
+                }
+            }
+        }
+    ],
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "extra": {
+        "laminas-migration": {
+            "nonMigratedPackages": {
+                "foo/bar": {
+                    "zendframework/zend-mvc": "^3.1"
+                },
+                "bar/baz": {
+                    "zendframework/zend-mvc": "^2.7 || ^3.0"
+                }
+            }
+        }
+    }
+}

--- a/integration/installs/multiple-non-migrated-libraries-sharing-zend-dependencies/composer.json
+++ b/integration/installs/multiple-non-migrated-libraries-sharing-zend-dependencies/composer.json
@@ -1,0 +1,44 @@
+{
+    "name": "laminas/project-with-multiple-non-migrated-libraries-which-share-zend-packages",
+    "license": "BSD-3-Clause",
+    "description": "Test project to integration test laminas-dependency-plugin",
+    "require": {
+        "foo/bar": "^1.0",
+        "bar/baz": "^1.0",
+        "laminas/laminas-dependency-plugin": "*",
+        "psr/log": "^1.0"
+    },
+    "config": {
+        "sort-packages": true
+    },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "/tmp/laminas-dependency-plugin"
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "foo/bar",
+                "version": "1.0",
+                "type": "metapackage",
+                "require": {
+                    "zendframework/zend-mvc": "^3.1"
+                }
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "bar/baz",
+                "version": "1.0",
+                "type": "metapackage",
+                "require": {
+                    "zendframework/zend-mvc": "^2.7 || ^3.0"
+                }
+            }
+        }
+    ],
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/integration/installs/multiple-non-migrated-libraries-sharing-zend-dependencies/composer.json.out
+++ b/integration/installs/multiple-non-migrated-libraries-sharing-zend-dependencies/composer.json.out
@@ -1,0 +1,58 @@
+{
+    "name": "laminas/project-with-multiple-non-migrated-libraries-which-share-zend-packages",
+    "license": "BSD-3-Clause",
+    "description": "Test project to integration test laminas-dependency-plugin",
+    "require": {
+        "foo/bar": "^1.0",
+        "bar/baz": "^1.0",
+        "laminas/laminas-dependency-plugin": "*",
+        "laminas/laminas-mvc": "^2.7 || ^3.0",
+        "psr/log": "^1.0"
+    },
+    "config": {
+        "sort-packages": true
+    },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "/tmp/laminas-dependency-plugin"
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "foo/bar",
+                "version": "1.0",
+                "type": "metapackage",
+                "require": {
+                    "zendframework/zend-mvc": "^3.1"
+                }
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "bar/baz",
+                "version": "1.0",
+                "type": "metapackage",
+                "require": {
+                    "zendframework/zend-mvc": "^2.7 || ^3.0"
+                }
+            }
+        }
+    ],
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "extra": {
+        "laminas-migration": {
+            "nonMigratedPackages": {
+                "foo/bar": {
+                    "zendframework/zend-mvc": "^3.1"
+                },
+                "bar/baz": {
+                    "zendframework/zend-mvc": "^2.7 || ^3.0"
+                }
+            }
+        }
+    }
+}
+

--- a/integration/installs/non-migrated-library-sort-packages/composer.json
+++ b/integration/installs/non-migrated-library-sort-packages/composer.json
@@ -1,0 +1,32 @@
+{
+    "name": "laminas/project-with-non-migrated-library-sort-packages",
+    "license": "BSD-3-Clause",
+    "description": "Test project to integration test laminas-dependency-plugin",
+    "require": {
+        "foo/bar": "^1.0",
+        "laminas/laminas-dependency-plugin": "*",
+        "psr/log": "^1.0"
+    },
+    "config": {
+        "sort-packages": true
+    },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "/tmp/laminas-dependency-plugin"
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "foo/bar",
+                "version": "1.0",
+                "type": "metapackage",
+                "require": {
+                    "zendframework/zend-mvc": "^3.1"
+                }
+            }
+        }
+    ],
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/integration/installs/non-migrated-library-sort-packages/composer.json.out
+++ b/integration/installs/non-migrated-library-sort-packages/composer.json.out
@@ -1,0 +1,42 @@
+{
+    "name": "laminas/project-with-non-migrated-library-sort-packages",
+    "license": "BSD-3-Clause",
+    "description": "Test project to integration test laminas-dependency-plugin",
+    "require": {
+        "foo/bar": "^1.0",
+        "laminas/laminas-dependency-plugin": "*",
+        "laminas/laminas-mvc": "^3.1",
+        "psr/log": "^1.0"
+    },
+    "config": {
+        "sort-packages": true
+    },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "/tmp/laminas-dependency-plugin"
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "foo/bar",
+                "version": "1.0",
+                "type": "metapackage",
+                "require": {
+                    "zendframework/zend-mvc": "^3.1"
+                }
+            }
+        }
+    ],
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "extra": {
+        "laminas-migration": {
+            "nonMigratedPackages": {
+                "foo/bar": {
+                    "zendframework/zend-mvc": "^3.1"
+                }
+            }
+        }
+    }
+}

--- a/integration/installs/single-non-migrated-library/composer.json
+++ b/integration/installs/single-non-migrated-library/composer.json
@@ -1,0 +1,28 @@
+{
+    "name": "laminas/project-with-single-non-migrated-library",
+    "license": "BSD-3-Clause",
+    "description": "Test project to integration test laminas-dependency-plugin",
+    "require": {
+        "foo/bar": "^1.0",
+        "laminas/laminas-dependency-plugin": "*"
+    },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "/tmp/laminas-dependency-plugin"
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "foo/bar",
+                "version": "1.0",
+                "type": "metapackage",
+                "require": {
+                    "zendframework/zend-mvc": "^3.1"
+                }
+            }
+        }
+    ],
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/integration/installs/single-non-migrated-library/composer.json.out
+++ b/integration/installs/single-non-migrated-library/composer.json.out
@@ -1,0 +1,38 @@
+{
+    "name": "laminas/project-with-single-non-migrated-library",
+    "license": "BSD-3-Clause",
+    "description": "Test project to integration test laminas-dependency-plugin",
+    "require": {
+        "foo/bar": "^1.0",
+        "laminas/laminas-dependency-plugin": "*",
+        "laminas/laminas-mvc": "^3.1"
+    },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "/tmp/laminas-dependency-plugin"
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "foo/bar",
+                "version": "1.0",
+                "type": "metapackage",
+                "require": {
+                    "zendframework/zend-mvc": "^3.1"
+                }
+            }
+        }
+    ],
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "extra": {
+        "laminas-migration": {
+            "nonMigratedPackages": {
+                "foo/bar": {
+                    "zendframework/zend-mvc": "^3.1"
+                }
+            }
+        }
+    }
+}

--- a/integration/installs/unaware-non-migrated-library/composer.json
+++ b/integration/installs/unaware-non-migrated-library/composer.json
@@ -1,0 +1,39 @@
+{
+    "name": "laminas/project-which-is-unware-that-its-not-migrated",
+    "license": "BSD-3-Clause",
+    "description": "Test project to integration test laminas-dependency-plugin",
+    "require": {
+        "foo/bar": "^1.0",
+        "laminas/laminas-dependency-plugin": "*"
+    },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "/tmp/laminas-dependency-plugin"
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "foo/bar",
+                "version": "1.0",
+                "type": "metapackage",
+                "require": {
+                    "bar/baz": "^1.0"
+                }
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "bar/baz",
+                "version": "1.0",
+                "type": "metapackage",
+                "require": {
+                    "zendframework/zend-mvc": "^3.1"
+                }
+            }
+        }
+    ],
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/integration/installs/unaware-non-migrated-library/composer.json.out
+++ b/integration/installs/unaware-non-migrated-library/composer.json.out
@@ -1,0 +1,49 @@
+{
+    "name": "laminas/project-which-is-unware-that-its-not-migrated",
+    "license": "BSD-3-Clause",
+    "description": "Test project to integration test laminas-dependency-plugin",
+    "require": {
+        "foo/bar": "^1.0",
+        "laminas/laminas-dependency-plugin": "*",
+        "laminas/laminas-mvc": "^3.1"
+    },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "/tmp/laminas-dependency-plugin"
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "foo/bar",
+                "version": "1.0",
+                "type": "metapackage",
+                "require": {
+                    "bar/baz": "^1.0"
+                }
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "bar/baz",
+                "version": "1.0",
+                "type": "metapackage",
+                "require": {
+                    "zendframework/zend-mvc": "^3.1"
+                }
+            }
+        }
+    ],
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "extra": {
+        "laminas-migration": {
+            "nonMigratedPackages": {
+                "bar/baz": {
+                    "zendframework/zend-mvc": "^3.1"
+                }
+            }
+        }
+    }
+}

--- a/integration/uninstalls/removal-with-no-non-migrated-packages-left/.gitignore
+++ b/integration/uninstalls/removal-with-no-non-migrated-packages-left/.gitignore
@@ -1,0 +1,1 @@
+!composer.lock

--- a/integration/uninstalls/removal-with-no-non-migrated-packages-left/composer.json
+++ b/integration/uninstalls/removal-with-no-non-migrated-packages-left/composer.json
@@ -1,0 +1,71 @@
+{
+    "name": "laminas/project-with-no-non-migrated-packages-left",
+    "license": "BSD-3-Clause",
+    "description": "Test project to integration test laminas-dependency-plugin",
+    "require": {
+        "laminas/laminas-dependency-plugin": "*",
+        "laminas/laminas-mvc": "^3.1",
+        "foo/bar": "^1.0"
+    },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "/tmp/laminas-dependency-plugin"
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "foo/bar",
+                "version": "1.0",
+                "type": "metapackage",
+                "require": {
+                    "bar/baz": "^1.0"
+                }
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "foo/bar",
+                "version": "1.1",
+                "type": "metapackage",
+                "require": {
+                    "bar/baz": "^2.0"
+                }
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "bar/baz",
+                "version": "1.0",
+                "type": "metapackage",
+                "require": {
+                    "zendframework/zend-mvc": "^3.1"
+                }
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "bar/baz",
+                "version": "2.0",
+                "type": "metapackage",
+                "require": {
+                    "laminas/laminas-mvc": "^3.1"
+                }
+            }
+        }
+    ],
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "extra": {
+        "laminas-migration": {
+            "nonMigratedPackages": {
+                "foo/bar": {
+                    "zendframework/zend-mvc": "^3.1"
+                }
+            }
+        }
+    }
+}

--- a/integration/uninstalls/removal-with-no-non-migrated-packages-left/composer.json.out
+++ b/integration/uninstalls/removal-with-no-non-migrated-packages-left/composer.json.out
@@ -1,0 +1,60 @@
+{
+    "name": "laminas/project-with-no-non-migrated-packages-left",
+    "license": "BSD-3-Clause",
+    "description": "Test project to integration test laminas-dependency-plugin",
+    "require": {
+        "laminas/laminas-dependency-plugin": "*"
+    },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "/tmp/laminas-dependency-plugin"
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "foo/bar",
+                "version": "1.0",
+                "type": "metapackage",
+                "require": {
+                    "bar/baz": "^1.0"
+                }
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "foo/bar",
+                "version": "1.1",
+                "type": "metapackage",
+                "require": {
+                    "bar/baz": "^2.0"
+                }
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "bar/baz",
+                "version": "1.0",
+                "type": "metapackage",
+                "require": {
+                    "zendframework/zend-mvc": "^3.1"
+                }
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "bar/baz",
+                "version": "2.0",
+                "type": "metapackage",
+                "require": {
+                    "laminas/laminas-mvc": "^3.1"
+                }
+            }
+        }
+    ],
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/integration/uninstalls/removal-with-no-non-migrated-packages-left/composer.lock
+++ b/integration/uninstalls/removal-with-no-non-migrated-packages-left/composer.lock
@@ -1,0 +1,1121 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "361c04314f8e7f2eefa640c023b6dad4",
+    "packages": [
+        {
+            "name": "bar/baz",
+            "version": "2.0",
+            "require": {
+                "laminas/laminas-mvc": "^3.1"
+            },
+            "type": "metapackage"
+        },
+        {
+            "name": "container-interop/container-interop",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/container-interop/container-interop.git",
+                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/79cbf1341c22ec75643d841642dd5d6acd83bdb8",
+                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8",
+                "shasum": ""
+            },
+            "require": {
+                "psr/container": "^1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Interop\\Container\\": "src/Interop/Container/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
+            "homepage": "https://github.com/container-interop/container-interop",
+            "abandoned": "psr/container",
+            "time": "2017-02-14T19:40:03+00:00"
+        },
+        {
+            "name": "foo/bar",
+            "version": "1.1",
+            "require": {
+                "bar/baz": "^2.0"
+            },
+            "type": "metapackage"
+        },
+        {
+            "name": "laminas/laminas-config",
+            "version": "3.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-config.git",
+                "reference": "b8fe057f55e69a0e7a2e4ced79218a43f58606a8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-config/zipball/b8fe057f55e69a0e7a2e4ced79218a43f58606a8",
+                "reference": "b8fe057f55e69a0e7a2e4ced79218a43f58606a8",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "laminas/laminas-stdlib": "^2.7.7 || ^3.1",
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^5.6 || ^7.0",
+                "psr/container": "^1.0"
+            },
+            "conflict": {
+                "container-interop/container-interop": "<1.2.0"
+            },
+            "replace": {
+                "zendframework/zend-config": "self.version"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-filter": "^2.7.2",
+                "laminas/laminas-i18n": "^2.7.4",
+                "laminas/laminas-servicemanager": "^2.7.8 || ^3.3",
+                "malukenho/docheader": "^0.1.6",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2"
+            },
+            "suggest": {
+                "laminas/laminas-filter": "^2.7.2; install if you want to use the Filter processor",
+                "laminas/laminas-i18n": "^2.7.4; install if you want to use the Translator processor",
+                "laminas/laminas-servicemanager": "^2.7.8 || ^3.3; if you need an extensible plugin manager for use with the Config Factory"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3.x-dev",
+                    "dev-develop": "3.4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Config\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "provides a nested object property based user interface for accessing this configuration data within application code",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "config",
+                "laminas"
+            ],
+            "time": "2019-12-31T16:30:11+00:00"
+        },
+        {
+            "name": "laminas/laminas-dependency-plugin",
+            "version": "dev-develop",
+            "dist": {
+                "type": "path",
+                "url": "/tmp/laminas-dependency-plugin",
+                "reference": "bc573d4cd22bcd4c7aa03825ebb07ee0f56728cd"
+            },
+            "require": {
+                "composer-plugin-api": "^1.1 || ^2.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "composer/composer": "^1.9 || ^2.0@dev",
+                "mikey179/vfsstream": "^1.6",
+                "phpcompatibility/php-compatibility": "^9.3",
+                "roave/security-advisories": "dev-master"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev",
+                    "dev-develop": "1.1.x-dev"
+                },
+                "class": "Laminas\\DependencyPlugin\\DependencyRewriterPlugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\DependencyPlugin\\": "src/"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "LaminasTest\\DependencyPlugin\\": "test/"
+                }
+            },
+            "scripts": {
+                "check": [
+                    "@cs-check",
+                    "@test"
+                ],
+                "cs-check": [
+                    "phpcs"
+                ],
+                "cs-fix": [
+                    "phpcbf"
+                ],
+                "test": [
+                    "phpunit --colors=always"
+                ],
+                "test-coverage": [
+                    "phpunit --colors=always --coverage-clover clover.xml"
+                ]
+            },
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Replace zendframework and zfcampus packages with their Laminas Project equivalents.",
+            "transport-options": {
+                "relative": false
+            }
+        },
+        {
+            "name": "laminas/laminas-escaper",
+            "version": "2.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-escaper.git",
+                "reference": "25f2a053eadfa92ddacb609dcbbc39362610da70"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-escaper/zipball/25f2a053eadfa92ddacb609dcbbc39362610da70",
+                "reference": "25f2a053eadfa92ddacb609dcbbc39362610da70",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "replace": {
+                "zendframework/zend-escaper": "self.version"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6.x-dev",
+                    "dev-develop": "2.7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Escaper\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Securely and safely escape HTML, HTML attributes, JavaScript, CSS, and URLs",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "escaper",
+                "laminas"
+            ],
+            "time": "2019-12-31T16:43:30+00:00"
+        },
+        {
+            "name": "laminas/laminas-eventmanager",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-eventmanager.git",
+                "reference": "ce4dc0bdf3b14b7f9815775af9dfee80a63b4748"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-eventmanager/zipball/ce4dc0bdf3b14b7f9815775af9dfee80a63b4748",
+                "reference": "ce4dc0bdf3b14b7f9815775af9dfee80a63b4748",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "replace": {
+                "zendframework/zend-eventmanager": "self.version"
+            },
+            "require-dev": {
+                "athletic/athletic": "^0.1",
+                "container-interop/container-interop": "^1.1.0",
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-stdlib": "^2.7.3 || ^3.0",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2"
+            },
+            "suggest": {
+                "container-interop/container-interop": "^1.1.0, to use the lazy listeners feature",
+                "laminas/laminas-stdlib": "^2.7.3 || ^3.0, to use the FilterChain feature"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev",
+                    "dev-develop": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\EventManager\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Trigger and listen to events within a PHP application",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "event",
+                "eventmanager",
+                "events",
+                "laminas"
+            ],
+            "time": "2019-12-31T16:44:52+00:00"
+        },
+        {
+            "name": "laminas/laminas-http",
+            "version": "2.11.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-http.git",
+                "reference": "8c66963b933c80da59433da56a44dfa979f3ec88"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-http/zipball/8c66963b933c80da59433da56a44dfa979f3ec88",
+                "reference": "8c66963b933c80da59433da56a44dfa979f3ec88",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-loader": "^2.5.1",
+                "laminas/laminas-stdlib": "^3.2.1",
+                "laminas/laminas-uri": "^2.5.2",
+                "laminas/laminas-validator": "^2.10.1",
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "replace": {
+                "zendframework/zend-http": "self.version"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-config": "^3.1 || ^2.6",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.3"
+            },
+            "suggest": {
+                "paragonie/certainty": "For automated management of cacert.pem"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.11.x-dev",
+                    "dev-develop": "2.12.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Http\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Provides an easy interface for performing Hyper-Text Transfer Protocol (HTTP) requests",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "http",
+                "http client",
+                "laminas"
+            ],
+            "time": "2019-12-31T17:02:36+00:00"
+        },
+        {
+            "name": "laminas/laminas-json",
+            "version": "3.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-json.git",
+                "reference": "00dc0da7b5e5018904c5c4a8e80a5faa16c2c1c6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-json/zipball/00dc0da7b5e5018904c5c4a8e80a5faa16c2c1c6",
+                "reference": "00dc0da7b5e5018904c5c4a8e80a5faa16c2c1c6",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "replace": {
+                "zendframework/zend-json": "self.version"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-stdlib": "^2.7.7 || ^3.1",
+                "phpunit/phpunit": "^5.7.23 || ^6.4.3"
+            },
+            "suggest": {
+                "laminas/laminas-json-server": "For implementing JSON-RPC servers",
+                "laminas/laminas-xml2json": "For converting XML documents to JSON"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1.x-dev",
+                    "dev-develop": "3.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Json\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "provides convenience methods for serializing native PHP to JSON and decoding JSON to native PHP",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "json",
+                "laminas"
+            ],
+            "time": "2019-12-31T17:15:04+00:00"
+        },
+        {
+            "name": "laminas/laminas-loader",
+            "version": "2.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-loader.git",
+                "reference": "5d01c2c237ae9e68bec262f339947e2ea18979bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-loader/zipball/5d01c2c237ae9e68bec262f339947e2ea18979bc",
+                "reference": "5d01c2c237ae9e68bec262f339947e2ea18979bc",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "replace": {
+                "zendframework/zend-loader": "self.version"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6.x-dev",
+                    "dev-develop": "2.7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Loader\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Autoloading and plugin loading strategies",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "loader"
+            ],
+            "time": "2019-12-31T17:18:27+00:00"
+        },
+        {
+            "name": "laminas/laminas-modulemanager",
+            "version": "2.8.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-modulemanager.git",
+                "reference": "92b1cde1aab5aef687b863face6dd5d9c6751c78"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-modulemanager/zipball/92b1cde1aab5aef687b863face6dd5d9c6751c78",
+                "reference": "92b1cde1aab5aef687b863face6dd5d9c6751c78",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-config": "^3.1 || ^2.6",
+                "laminas/laminas-eventmanager": "^3.2 || ^2.6.3",
+                "laminas/laminas-stdlib": "^3.1 || ^2.7",
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "replace": {
+                "zendframework/zend-modulemanager": "self.version"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-console": "^2.6",
+                "laminas/laminas-di": "^2.6",
+                "laminas/laminas-loader": "^2.5",
+                "laminas/laminas-mvc": "^3.0 || ^2.7",
+                "laminas/laminas-servicemanager": "^3.0.3 || ^2.7.5",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.5.16"
+            },
+            "suggest": {
+                "laminas/laminas-console": "Laminas\\Console component",
+                "laminas/laminas-loader": "Laminas\\Loader component if you are not using Composer autoloading for your modules",
+                "laminas/laminas-mvc": "Laminas\\Mvc component",
+                "laminas/laminas-servicemanager": "Laminas\\ServiceManager component"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8.x-dev",
+                    "dev-develop": "2.9.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\ModuleManager\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Modular application system for laminas-mvc applications",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "modulemanager"
+            ],
+            "time": "2019-12-31T17:26:56+00:00"
+        },
+        {
+            "name": "laminas/laminas-mvc",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-mvc.git",
+                "reference": "ead09f8ab5ff0e562dbd0198c7f67523c2f61980"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-mvc/zipball/ead09f8ab5ff0e562dbd0198c7f67523c2f61980",
+                "reference": "ead09f8ab5ff0e562dbd0198c7f67523c2f61980",
+                "shasum": ""
+            },
+            "require": {
+                "container-interop/container-interop": "^1.2",
+                "laminas/laminas-eventmanager": "^3.2",
+                "laminas/laminas-http": "^2.7",
+                "laminas/laminas-modulemanager": "^2.8",
+                "laminas/laminas-router": "^3.0.2",
+                "laminas/laminas-servicemanager": "^3.3",
+                "laminas/laminas-stdlib": "^3.1",
+                "laminas/laminas-view": "^2.9",
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "replace": {
+                "zendframework/zend-mvc": "self.version"
+            },
+            "require-dev": {
+                "http-interop/http-middleware": "^0.4.1",
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-json": "^2.6.1 || ^3.0",
+                "laminas/laminas-psr7bridge": "^1.0",
+                "laminas/laminas-stratigility": "^2.0.1",
+                "phpunit/phpunit": "^6.4.4 || ^5.7.14"
+            },
+            "suggest": {
+                "http-interop/http-middleware": "^0.4.1 to be used together with laminas-stratigility",
+                "laminas/laminas-json": "(^2.6.1 || ^3.0) To auto-deserialize JSON body content in AbstractRestfulController extensions, when json_decode is unavailable",
+                "laminas/laminas-log": "^2.9.1  To provide log functionality via LogFilterManager, LogFormatterManager, and LogProcessorManager",
+                "laminas/laminas-mvc-console": "laminas-mvc-console provides the ability to expose laminas-mvc as a console application",
+                "laminas/laminas-mvc-i18n": "laminas-mvc-i18n provides integration with laminas-i18n, including a translation bridge and translatable route segments",
+                "laminas/laminas-mvc-plugin-fileprg": "To provide Post/Redirect/Get functionality around forms that container file uploads",
+                "laminas/laminas-mvc-plugin-flashmessenger": "To provide flash messaging capabilities between requests",
+                "laminas/laminas-mvc-plugin-identity": "To access the authenticated identity (per laminas-authentication) in controllers",
+                "laminas/laminas-mvc-plugin-prg": "To provide Post/Redirect/Get functionality within controllers",
+                "laminas/laminas-paginator": "^2.7 To provide pagination functionality via PaginatorPluginManager",
+                "laminas/laminas-psr7bridge": "(^0.2) To consume PSR-7 middleware within the MVC workflow",
+                "laminas/laminas-servicemanager-di": "laminas-servicemanager-di provides utilities for integrating laminas-di and laminas-servicemanager in your laminas-mvc application",
+                "laminas/laminas-stratigility": "laminas-stratigility is required to use middleware pipes in the MiddlewareListener"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev",
+                    "dev-develop": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Mvc\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Laminas's event-driven MVC layer, including MVC Applications, Controllers, and Plugins",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "mvc"
+            ],
+            "time": "2019-12-31T17:33:14+00:00"
+        },
+        {
+            "name": "laminas/laminas-router",
+            "version": "3.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-router.git",
+                "reference": "01a6905202ad41a42ba63d60260eba32b89e18c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-router/zipball/01a6905202ad41a42ba63d60260eba32b89e18c7",
+                "reference": "01a6905202ad41a42ba63d60260eba32b89e18c7",
+                "shasum": ""
+            },
+            "require": {
+                "container-interop/container-interop": "^1.2",
+                "laminas/laminas-http": "^2.8.1",
+                "laminas/laminas-servicemanager": "^2.7.8 || ^3.3",
+                "laminas/laminas-stdlib": "^3.2.1",
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "conflict": {
+                "laminas/laminas-mvc": "<3.0.0"
+            },
+            "replace": {
+                "zendframework/zend-router": "^3.3.0"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-i18n": "^2.7.4",
+                "phpunit/phpunit": "^5.7.22 || ^6.4.1 || ^7.5.18"
+            },
+            "suggest": {
+                "laminas/laminas-i18n": "^2.7.4, if defining translatable HTTP path segments"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3.x-dev",
+                    "dev-develop": "4.0.x-dev"
+                },
+                "laminas": {
+                    "component": "Laminas\\Router",
+                    "config-provider": "Laminas\\Router\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Router\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Flexible routing system for HTTP and console applications",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "mvc",
+                "routing"
+            ],
+            "time": "2020-03-29T13:21:03+00:00"
+        },
+        {
+            "name": "laminas/laminas-servicemanager",
+            "version": "3.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-servicemanager.git",
+                "reference": "0d4c8628a71fae9f7bd0b1b74b76382e5e9a04b1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/0d4c8628a71fae9f7bd0b1b74b76382e5e9a04b1",
+                "reference": "0d4c8628a71fae9f7bd0b1b74b76382e5e9a04b1",
+                "shasum": ""
+            },
+            "require": {
+                "container-interop/container-interop": "^1.2",
+                "laminas/laminas-stdlib": "^3.2.1",
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^5.6 || ^7.0",
+                "psr/container": "^1.0"
+            },
+            "provide": {
+                "container-interop/container-interop-implementation": "^1.2",
+                "psr/container-implementation": "^1.0"
+            },
+            "replace": {
+                "zendframework/zend-servicemanager": "^3.4.0"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "mikey179/vfsstream": "^1.6.5",
+                "ocramius/proxy-manager": "^1.0 || ^2.0",
+                "phpbench/phpbench": "^0.13.0",
+                "phpunit/phpunit": "^5.7.25 || ^6.4.4"
+            },
+            "suggest": {
+                "laminas/laminas-stdlib": "laminas-stdlib ^2.5 if you wish to use the MergeReplaceKey or MergeRemoveKey features in Config instances",
+                "ocramius/proxy-manager": "ProxyManager 1.* to handle lazy initialization of services"
+            },
+            "bin": [
+                "bin/generate-deps-for-config-factory",
+                "bin/generate-factory-for-class"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev",
+                    "dev-develop": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\ServiceManager\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Factory-Driven Dependency Injection Container",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "PSR-11",
+                "dependency-injection",
+                "di",
+                "dic",
+                "laminas",
+                "service-manager",
+                "servicemanager"
+            ],
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2020-05-11T14:43:22+00:00"
+        },
+        {
+            "name": "laminas/laminas-stdlib",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-stdlib.git",
+                "reference": "2b18347625a2f06a1a485acfbc870f699dbe51c6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/2b18347625a2f06a1a485acfbc870f699dbe51c6",
+                "reference": "2b18347625a2f06a1a485acfbc870f699dbe51c6",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "replace": {
+                "zendframework/zend-stdlib": "self.version"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "phpbench/phpbench": "^0.13",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2.x-dev",
+                    "dev-develop": "3.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Stdlib\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "SPL extensions, array utilities, error handlers, and more",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "stdlib"
+            ],
+            "time": "2019-12-31T17:51:15+00:00"
+        },
+        {
+            "name": "laminas/laminas-uri",
+            "version": "2.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-uri.git",
+                "reference": "6be8ce19622f359b048ce4faebf1aa1bca73a7ff"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-uri/zipball/6be8ce19622f359b048ce4faebf1aa1bca73a7ff",
+                "reference": "6be8ce19622f359b048ce4faebf1aa1bca73a7ff",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-escaper": "^2.5",
+                "laminas/laminas-validator": "^2.10",
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "replace": {
+                "zendframework/zend-uri": "self.version"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7.x-dev",
+                    "dev-develop": "2.8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Uri\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "A component that aids in manipulating and validating » Uniform Resource Identifiers (URIs)",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "uri"
+            ],
+            "time": "2019-12-31T17:56:00+00:00"
+        },
+        {
+            "name": "laminas/laminas-validator",
+            "version": "2.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-validator.git",
+                "reference": "93593684e70b8ed1e870cacd34ca32b0c0ace185"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/93593684e70b8ed1e870cacd34ca32b0c0ace185",
+                "reference": "93593684e70b8ed1e870cacd34ca32b0c0ace185",
+                "shasum": ""
+            },
+            "require": {
+                "container-interop/container-interop": "^1.1",
+                "laminas/laminas-stdlib": "^3.2.1",
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^7.1"
+            },
+            "replace": {
+                "zendframework/zend-validator": "^2.13.0"
+            },
+            "require-dev": {
+                "laminas/laminas-cache": "^2.6.1",
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-config": "^2.6",
+                "laminas/laminas-db": "^2.7",
+                "laminas/laminas-filter": "^2.6",
+                "laminas/laminas-http": "^2.5.4",
+                "laminas/laminas-i18n": "^2.6",
+                "laminas/laminas-math": "^2.6",
+                "laminas/laminas-servicemanager": "^2.7.5 || ^3.0.3",
+                "laminas/laminas-session": "^2.8",
+                "laminas/laminas-uri": "^2.5",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.2",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.0"
+            },
+            "suggest": {
+                "laminas/laminas-db": "Laminas\\Db component, required by the (No)RecordExists validator",
+                "laminas/laminas-filter": "Laminas\\Filter component, required by the Digits validator",
+                "laminas/laminas-i18n": "Laminas\\I18n component to allow translation of validation error messages",
+                "laminas/laminas-i18n-resources": "Translations of validator messages",
+                "laminas/laminas-math": "Laminas\\Math component, required by the Csrf validator",
+                "laminas/laminas-servicemanager": "Laminas\\ServiceManager component to allow using the ValidatorPluginManager and validator chains",
+                "laminas/laminas-session": "Laminas\\Session component, ^2.8; required by the Csrf validator",
+                "laminas/laminas-uri": "Laminas\\Uri component, required by the Uri and Sitemap\\Loc validators",
+                "psr/http-message": "psr/http-message, required when validating PSR-7 UploadedFileInterface instances via the Upload and UploadFile validators"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.13.x-dev",
+                    "dev-develop": "2.14.x-dev"
+                },
+                "laminas": {
+                    "component": "Laminas\\Validator",
+                    "config-provider": "Laminas\\Validator\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Validator\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Validation classes for a wide range of domains, and the ability to chain validators to create complex validation criteria",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "validator"
+            ],
+            "time": "2020-03-31T18:57:01+00:00"
+        },
+        {
+            "name": "laminas/laminas-view",
+            "version": "2.11.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-view.git",
+                "reference": "3bbb2e94287383604c898284a18d2d06cf17301e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-view/zipball/3bbb2e94287383604c898284a18d2d06cf17301e",
+                "reference": "3bbb2e94287383604c898284a18d2d06cf17301e",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-eventmanager": "^2.6.2 || ^3.0",
+                "laminas/laminas-json": "^2.6.1 || ^3.0",
+                "laminas/laminas-loader": "^2.5",
+                "laminas/laminas-stdlib": "^2.7 || ^3.0",
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "replace": {
+                "zendframework/zend-view": "self.version"
+            },
+            "require-dev": {
+                "laminas/laminas-authentication": "^2.5",
+                "laminas/laminas-cache": "^2.6.1",
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-config": "^2.6",
+                "laminas/laminas-console": "^2.6",
+                "laminas/laminas-escaper": "^2.5",
+                "laminas/laminas-feed": "^2.7",
+                "laminas/laminas-filter": "^2.6.1",
+                "laminas/laminas-http": "^2.5.4",
+                "laminas/laminas-i18n": "^2.6",
+                "laminas/laminas-log": "^2.7",
+                "laminas/laminas-modulemanager": "^2.7.1",
+                "laminas/laminas-mvc": "^2.7.14 || ^3.0",
+                "laminas/laminas-navigation": "^2.5",
+                "laminas/laminas-paginator": "^2.5",
+                "laminas/laminas-permissions-acl": "^2.6",
+                "laminas/laminas-router": "^3.0.1",
+                "laminas/laminas-serializer": "^2.6.1",
+                "laminas/laminas-servicemanager": "^2.7.5 || ^3.0.3",
+                "laminas/laminas-session": "^2.8.1",
+                "laminas/laminas-uri": "^2.5",
+                "phpunit/phpunit": "^5.7.15 || ^6.0.8"
+            },
+            "suggest": {
+                "laminas/laminas-authentication": "Laminas\\Authentication component",
+                "laminas/laminas-escaper": "Laminas\\Escaper component",
+                "laminas/laminas-feed": "Laminas\\Feed component",
+                "laminas/laminas-filter": "Laminas\\Filter component",
+                "laminas/laminas-http": "Laminas\\Http component",
+                "laminas/laminas-i18n": "Laminas\\I18n component",
+                "laminas/laminas-mvc": "Laminas\\Mvc component",
+                "laminas/laminas-mvc-plugin-flashmessenger": "laminas-mvc-plugin-flashmessenger component, if you want to use the FlashMessenger view helper with laminas-mvc versions 3 and up",
+                "laminas/laminas-navigation": "Laminas\\Navigation component",
+                "laminas/laminas-paginator": "Laminas\\Paginator component",
+                "laminas/laminas-permissions-acl": "Laminas\\Permissions\\Acl component",
+                "laminas/laminas-servicemanager": "Laminas\\ServiceManager component",
+                "laminas/laminas-uri": "Laminas\\Uri component"
+            },
+            "bin": [
+                "bin/templatemap_generator.php"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.11.x-dev",
+                    "dev-develop": "2.12.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\View\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Flexible view layer supporting and providing multiple view layers, helpers, and more",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "view"
+            ],
+            "time": "2019-12-31T18:03:30+00:00"
+        },
+        {
+            "name": "laminas/laminas-zendframework-bridge",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
+                "reference": "bfbbdb6c998d50dbf69d2187cb78a5f1fa36e1e9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/bfbbdb6c998d50dbf69d2187cb78a5f1fa36e1e9",
+                "reference": "bfbbdb6c998d50dbf69d2187cb78a5f1fa36e1e9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.1",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev",
+                    "dev-develop": "1.1.x-dev"
+                },
+                "laminas": {
+                    "module": "Laminas\\ZendFrameworkBridge"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/autoload.php"
+                ],
+                "psr-4": {
+                    "Laminas\\ZendFrameworkBridge\\": "src//"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Alias legacy ZF class names to Laminas Project equivalents.",
+            "keywords": [
+                "ZendFramework",
+                "autoloading",
+                "laminas",
+                "zf"
+            ],
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2020-04-03T16:01:00+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "time": "2017-02-14T16:28:37+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "dev",
+    "stability-flags": [],
+    "prefer-stable": true,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
+}

--- a/integration/uninstalls/removal-with-no-non-migrated-packages-left/composer.sh
+++ b/integration/uninstalls/removal-with-no-non-migrated-packages-left/composer.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+# Install all packages before removing
+composer install --no-interaction --working-dir=$1
+
+composer remove foo/bar --no-interaction --working-dir=$1
+composer validate --no-check-all --working-dir=$1

--- a/integration/updates/non-migrated-package-to-migrated-package/.gitignore
+++ b/integration/updates/non-migrated-package-to-migrated-package/.gitignore
@@ -1,0 +1,1 @@
+!composer.lock

--- a/integration/updates/non-migrated-package-to-migrated-package/composer.json
+++ b/integration/updates/non-migrated-package-to-migrated-package/composer.json
@@ -1,0 +1,49 @@
+{
+    "name": "laminas/project-with-no-non-migrated-packages-left",
+    "license": "BSD-3-Clause",
+    "description": "Test project to integration test laminas-dependency-plugin",
+    "require": {
+        "laminas/laminas-dependency-plugin": "*",
+        "bar/baz": "^1.0",
+        "laminas/laminas-mvc": "^3.1"
+    },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "/tmp/laminas-dependency-plugin"
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "bar/baz",
+                "version": "1.0",
+                "type": "metapackage",
+                "require": {
+                    "zendframework/zend-mvc": "^3.1"
+                }
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "bar/baz",
+                "version": "2.0",
+                "type": "metapackage",
+                "require": {
+                    "laminas/laminas-mvc": "^3.1"
+                }
+            }
+        }
+    ],
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "extra": {
+        "laminas-migration": {
+            "nonMigratedPackages": {
+                "bar/baz": {
+                    "zendframework/zend-mvc": "^3.1"
+                }
+            }
+        }
+    }
+}

--- a/integration/updates/non-migrated-package-to-migrated-package/composer.json.out
+++ b/integration/updates/non-migrated-package-to-migrated-package/composer.json.out
@@ -1,0 +1,39 @@
+{
+    "name": "laminas/project-with-no-non-migrated-packages-left",
+    "license": "BSD-3-Clause",
+    "description": "Test project to integration test laminas-dependency-plugin",
+    "require": {
+        "laminas/laminas-dependency-plugin": "*",
+        "bar/baz": "^2.0"
+    },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "/tmp/laminas-dependency-plugin"
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "bar/baz",
+                "version": "1.0",
+                "type": "metapackage",
+                "require": {
+                    "zendframework/zend-mvc": "^3.1"
+                }
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "bar/baz",
+                "version": "2.0",
+                "type": "metapackage",
+                "require": {
+                    "laminas/laminas-mvc": "^3.1"
+                }
+            }
+        }
+    ],
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/integration/updates/non-migrated-package-to-migrated-package/composer.lock
+++ b/integration/updates/non-migrated-package-to-migrated-package/composer.lock
@@ -1,0 +1,1113 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "b446b9bb0b990e0d2585ce881778d663",
+    "packages": [
+        {
+            "name": "bar/baz",
+            "version": "1.0",
+            "require": {
+                "zendframework/zend-mvc": "^3.1"
+            },
+            "type": "metapackage"
+        },
+        {
+            "name": "container-interop/container-interop",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/container-interop/container-interop.git",
+                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/79cbf1341c22ec75643d841642dd5d6acd83bdb8",
+                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8",
+                "shasum": ""
+            },
+            "require": {
+                "psr/container": "^1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Interop\\Container\\": "src/Interop/Container/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
+            "homepage": "https://github.com/container-interop/container-interop",
+            "abandoned": "psr/container",
+            "time": "2017-02-14T19:40:03+00:00"
+        },
+        {
+            "name": "laminas/laminas-config",
+            "version": "3.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-config.git",
+                "reference": "b8fe057f55e69a0e7a2e4ced79218a43f58606a8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-config/zipball/b8fe057f55e69a0e7a2e4ced79218a43f58606a8",
+                "reference": "b8fe057f55e69a0e7a2e4ced79218a43f58606a8",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "laminas/laminas-stdlib": "^2.7.7 || ^3.1",
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^5.6 || ^7.0",
+                "psr/container": "^1.0"
+            },
+            "conflict": {
+                "container-interop/container-interop": "<1.2.0"
+            },
+            "replace": {
+                "zendframework/zend-config": "self.version"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-filter": "^2.7.2",
+                "laminas/laminas-i18n": "^2.7.4",
+                "laminas/laminas-servicemanager": "^2.7.8 || ^3.3",
+                "malukenho/docheader": "^0.1.6",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2"
+            },
+            "suggest": {
+                "laminas/laminas-filter": "^2.7.2; install if you want to use the Filter processor",
+                "laminas/laminas-i18n": "^2.7.4; install if you want to use the Translator processor",
+                "laminas/laminas-servicemanager": "^2.7.8 || ^3.3; if you need an extensible plugin manager for use with the Config Factory"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3.x-dev",
+                    "dev-develop": "3.4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Config\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "provides a nested object property based user interface for accessing this configuration data within application code",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "config",
+                "laminas"
+            ],
+            "time": "2019-12-31T16:30:11+00:00"
+        },
+        {
+            "name": "laminas/laminas-dependency-plugin",
+            "version": "dev-develop",
+            "dist": {
+                "type": "path",
+                "url": "/tmp/laminas-dependency-plugin",
+                "reference": "669a2b439df35537f846f9e201931550313c71c4"
+            },
+            "require": {
+                "composer-plugin-api": "^1.1 || ^2.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "composer/composer": "^1.9 || ^2.0@dev",
+                "mikey179/vfsstream": "^1.6",
+                "phpcompatibility/php-compatibility": "^9.3",
+                "roave/security-advisories": "dev-master"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev",
+                    "dev-develop": "1.1.x-dev"
+                },
+                "class": "Laminas\\DependencyPlugin\\DependencyRewriterPlugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\DependencyPlugin\\": "src/"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "LaminasTest\\DependencyPlugin\\": "test/"
+                }
+            },
+            "scripts": {
+                "check": [
+                    "@cs-check",
+                    "@test"
+                ],
+                "cs-check": [
+                    "phpcs"
+                ],
+                "cs-fix": [
+                    "phpcbf"
+                ],
+                "test": [
+                    "phpunit --colors=always"
+                ],
+                "test-coverage": [
+                    "phpunit --colors=always --coverage-clover clover.xml"
+                ]
+            },
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Replace zendframework and zfcampus packages with their Laminas Project equivalents.",
+            "transport-options": {
+                "relative": false
+            }
+        },
+        {
+            "name": "laminas/laminas-escaper",
+            "version": "2.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-escaper.git",
+                "reference": "25f2a053eadfa92ddacb609dcbbc39362610da70"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-escaper/zipball/25f2a053eadfa92ddacb609dcbbc39362610da70",
+                "reference": "25f2a053eadfa92ddacb609dcbbc39362610da70",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "replace": {
+                "zendframework/zend-escaper": "self.version"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6.x-dev",
+                    "dev-develop": "2.7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Escaper\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Securely and safely escape HTML, HTML attributes, JavaScript, CSS, and URLs",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "escaper",
+                "laminas"
+            ],
+            "time": "2019-12-31T16:43:30+00:00"
+        },
+        {
+            "name": "laminas/laminas-eventmanager",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-eventmanager.git",
+                "reference": "ce4dc0bdf3b14b7f9815775af9dfee80a63b4748"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-eventmanager/zipball/ce4dc0bdf3b14b7f9815775af9dfee80a63b4748",
+                "reference": "ce4dc0bdf3b14b7f9815775af9dfee80a63b4748",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "replace": {
+                "zendframework/zend-eventmanager": "self.version"
+            },
+            "require-dev": {
+                "athletic/athletic": "^0.1",
+                "container-interop/container-interop": "^1.1.0",
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-stdlib": "^2.7.3 || ^3.0",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2"
+            },
+            "suggest": {
+                "container-interop/container-interop": "^1.1.0, to use the lazy listeners feature",
+                "laminas/laminas-stdlib": "^2.7.3 || ^3.0, to use the FilterChain feature"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev",
+                    "dev-develop": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\EventManager\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Trigger and listen to events within a PHP application",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "event",
+                "eventmanager",
+                "events",
+                "laminas"
+            ],
+            "time": "2019-12-31T16:44:52+00:00"
+        },
+        {
+            "name": "laminas/laminas-http",
+            "version": "2.11.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-http.git",
+                "reference": "8c66963b933c80da59433da56a44dfa979f3ec88"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-http/zipball/8c66963b933c80da59433da56a44dfa979f3ec88",
+                "reference": "8c66963b933c80da59433da56a44dfa979f3ec88",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-loader": "^2.5.1",
+                "laminas/laminas-stdlib": "^3.2.1",
+                "laminas/laminas-uri": "^2.5.2",
+                "laminas/laminas-validator": "^2.10.1",
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "replace": {
+                "zendframework/zend-http": "self.version"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-config": "^3.1 || ^2.6",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.3"
+            },
+            "suggest": {
+                "paragonie/certainty": "For automated management of cacert.pem"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.11.x-dev",
+                    "dev-develop": "2.12.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Http\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Provides an easy interface for performing Hyper-Text Transfer Protocol (HTTP) requests",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "http",
+                "http client",
+                "laminas"
+            ],
+            "time": "2019-12-31T17:02:36+00:00"
+        },
+        {
+            "name": "laminas/laminas-json",
+            "version": "3.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-json.git",
+                "reference": "00dc0da7b5e5018904c5c4a8e80a5faa16c2c1c6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-json/zipball/00dc0da7b5e5018904c5c4a8e80a5faa16c2c1c6",
+                "reference": "00dc0da7b5e5018904c5c4a8e80a5faa16c2c1c6",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "replace": {
+                "zendframework/zend-json": "self.version"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-stdlib": "^2.7.7 || ^3.1",
+                "phpunit/phpunit": "^5.7.23 || ^6.4.3"
+            },
+            "suggest": {
+                "laminas/laminas-json-server": "For implementing JSON-RPC servers",
+                "laminas/laminas-xml2json": "For converting XML documents to JSON"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1.x-dev",
+                    "dev-develop": "3.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Json\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "provides convenience methods for serializing native PHP to JSON and decoding JSON to native PHP",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "json",
+                "laminas"
+            ],
+            "time": "2019-12-31T17:15:04+00:00"
+        },
+        {
+            "name": "laminas/laminas-loader",
+            "version": "2.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-loader.git",
+                "reference": "5d01c2c237ae9e68bec262f339947e2ea18979bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-loader/zipball/5d01c2c237ae9e68bec262f339947e2ea18979bc",
+                "reference": "5d01c2c237ae9e68bec262f339947e2ea18979bc",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "replace": {
+                "zendframework/zend-loader": "self.version"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6.x-dev",
+                    "dev-develop": "2.7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Loader\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Autoloading and plugin loading strategies",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "loader"
+            ],
+            "time": "2019-12-31T17:18:27+00:00"
+        },
+        {
+            "name": "laminas/laminas-modulemanager",
+            "version": "2.8.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-modulemanager.git",
+                "reference": "92b1cde1aab5aef687b863face6dd5d9c6751c78"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-modulemanager/zipball/92b1cde1aab5aef687b863face6dd5d9c6751c78",
+                "reference": "92b1cde1aab5aef687b863face6dd5d9c6751c78",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-config": "^3.1 || ^2.6",
+                "laminas/laminas-eventmanager": "^3.2 || ^2.6.3",
+                "laminas/laminas-stdlib": "^3.1 || ^2.7",
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "replace": {
+                "zendframework/zend-modulemanager": "self.version"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-console": "^2.6",
+                "laminas/laminas-di": "^2.6",
+                "laminas/laminas-loader": "^2.5",
+                "laminas/laminas-mvc": "^3.0 || ^2.7",
+                "laminas/laminas-servicemanager": "^3.0.3 || ^2.7.5",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.5.16"
+            },
+            "suggest": {
+                "laminas/laminas-console": "Laminas\\Console component",
+                "laminas/laminas-loader": "Laminas\\Loader component if you are not using Composer autoloading for your modules",
+                "laminas/laminas-mvc": "Laminas\\Mvc component",
+                "laminas/laminas-servicemanager": "Laminas\\ServiceManager component"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8.x-dev",
+                    "dev-develop": "2.9.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\ModuleManager\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Modular application system for laminas-mvc applications",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "modulemanager"
+            ],
+            "time": "2019-12-31T17:26:56+00:00"
+        },
+        {
+            "name": "laminas/laminas-mvc",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-mvc.git",
+                "reference": "ead09f8ab5ff0e562dbd0198c7f67523c2f61980"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-mvc/zipball/ead09f8ab5ff0e562dbd0198c7f67523c2f61980",
+                "reference": "ead09f8ab5ff0e562dbd0198c7f67523c2f61980",
+                "shasum": ""
+            },
+            "require": {
+                "container-interop/container-interop": "^1.2",
+                "laminas/laminas-eventmanager": "^3.2",
+                "laminas/laminas-http": "^2.7",
+                "laminas/laminas-modulemanager": "^2.8",
+                "laminas/laminas-router": "^3.0.2",
+                "laminas/laminas-servicemanager": "^3.3",
+                "laminas/laminas-stdlib": "^3.1",
+                "laminas/laminas-view": "^2.9",
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "replace": {
+                "zendframework/zend-mvc": "self.version"
+            },
+            "require-dev": {
+                "http-interop/http-middleware": "^0.4.1",
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-json": "^2.6.1 || ^3.0",
+                "laminas/laminas-psr7bridge": "^1.0",
+                "laminas/laminas-stratigility": "^2.0.1",
+                "phpunit/phpunit": "^6.4.4 || ^5.7.14"
+            },
+            "suggest": {
+                "http-interop/http-middleware": "^0.4.1 to be used together with laminas-stratigility",
+                "laminas/laminas-json": "(^2.6.1 || ^3.0) To auto-deserialize JSON body content in AbstractRestfulController extensions, when json_decode is unavailable",
+                "laminas/laminas-log": "^2.9.1  To provide log functionality via LogFilterManager, LogFormatterManager, and LogProcessorManager",
+                "laminas/laminas-mvc-console": "laminas-mvc-console provides the ability to expose laminas-mvc as a console application",
+                "laminas/laminas-mvc-i18n": "laminas-mvc-i18n provides integration with laminas-i18n, including a translation bridge and translatable route segments",
+                "laminas/laminas-mvc-plugin-fileprg": "To provide Post/Redirect/Get functionality around forms that container file uploads",
+                "laminas/laminas-mvc-plugin-flashmessenger": "To provide flash messaging capabilities between requests",
+                "laminas/laminas-mvc-plugin-identity": "To access the authenticated identity (per laminas-authentication) in controllers",
+                "laminas/laminas-mvc-plugin-prg": "To provide Post/Redirect/Get functionality within controllers",
+                "laminas/laminas-paginator": "^2.7 To provide pagination functionality via PaginatorPluginManager",
+                "laminas/laminas-psr7bridge": "(^0.2) To consume PSR-7 middleware within the MVC workflow",
+                "laminas/laminas-servicemanager-di": "laminas-servicemanager-di provides utilities for integrating laminas-di and laminas-servicemanager in your laminas-mvc application",
+                "laminas/laminas-stratigility": "laminas-stratigility is required to use middleware pipes in the MiddlewareListener"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev",
+                    "dev-develop": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Mvc\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Laminas's event-driven MVC layer, including MVC Applications, Controllers, and Plugins",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "mvc"
+            ],
+            "time": "2019-12-31T17:33:14+00:00"
+        },
+        {
+            "name": "laminas/laminas-router",
+            "version": "3.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-router.git",
+                "reference": "01a6905202ad41a42ba63d60260eba32b89e18c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-router/zipball/01a6905202ad41a42ba63d60260eba32b89e18c7",
+                "reference": "01a6905202ad41a42ba63d60260eba32b89e18c7",
+                "shasum": ""
+            },
+            "require": {
+                "container-interop/container-interop": "^1.2",
+                "laminas/laminas-http": "^2.8.1",
+                "laminas/laminas-servicemanager": "^2.7.8 || ^3.3",
+                "laminas/laminas-stdlib": "^3.2.1",
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "conflict": {
+                "laminas/laminas-mvc": "<3.0.0"
+            },
+            "replace": {
+                "zendframework/zend-router": "^3.3.0"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-i18n": "^2.7.4",
+                "phpunit/phpunit": "^5.7.22 || ^6.4.1 || ^7.5.18"
+            },
+            "suggest": {
+                "laminas/laminas-i18n": "^2.7.4, if defining translatable HTTP path segments"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3.x-dev",
+                    "dev-develop": "4.0.x-dev"
+                },
+                "laminas": {
+                    "component": "Laminas\\Router",
+                    "config-provider": "Laminas\\Router\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Router\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Flexible routing system for HTTP and console applications",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "mvc",
+                "routing"
+            ],
+            "time": "2020-03-29T13:21:03+00:00"
+        },
+        {
+            "name": "laminas/laminas-servicemanager",
+            "version": "3.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-servicemanager.git",
+                "reference": "0d4c8628a71fae9f7bd0b1b74b76382e5e9a04b1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/0d4c8628a71fae9f7bd0b1b74b76382e5e9a04b1",
+                "reference": "0d4c8628a71fae9f7bd0b1b74b76382e5e9a04b1",
+                "shasum": ""
+            },
+            "require": {
+                "container-interop/container-interop": "^1.2",
+                "laminas/laminas-stdlib": "^3.2.1",
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^5.6 || ^7.0",
+                "psr/container": "^1.0"
+            },
+            "provide": {
+                "container-interop/container-interop-implementation": "^1.2",
+                "psr/container-implementation": "^1.0"
+            },
+            "replace": {
+                "zendframework/zend-servicemanager": "^3.4.0"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "mikey179/vfsstream": "^1.6.5",
+                "ocramius/proxy-manager": "^1.0 || ^2.0",
+                "phpbench/phpbench": "^0.13.0",
+                "phpunit/phpunit": "^5.7.25 || ^6.4.4"
+            },
+            "suggest": {
+                "laminas/laminas-stdlib": "laminas-stdlib ^2.5 if you wish to use the MergeReplaceKey or MergeRemoveKey features in Config instances",
+                "ocramius/proxy-manager": "ProxyManager 1.* to handle lazy initialization of services"
+            },
+            "bin": [
+                "bin/generate-deps-for-config-factory",
+                "bin/generate-factory-for-class"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev",
+                    "dev-develop": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\ServiceManager\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Factory-Driven Dependency Injection Container",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "PSR-11",
+                "dependency-injection",
+                "di",
+                "dic",
+                "laminas",
+                "service-manager",
+                "servicemanager"
+            ],
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2020-05-11T14:43:22+00:00"
+        },
+        {
+            "name": "laminas/laminas-stdlib",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-stdlib.git",
+                "reference": "2b18347625a2f06a1a485acfbc870f699dbe51c6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/2b18347625a2f06a1a485acfbc870f699dbe51c6",
+                "reference": "2b18347625a2f06a1a485acfbc870f699dbe51c6",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "replace": {
+                "zendframework/zend-stdlib": "self.version"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "phpbench/phpbench": "^0.13",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2.x-dev",
+                    "dev-develop": "3.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Stdlib\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "SPL extensions, array utilities, error handlers, and more",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "stdlib"
+            ],
+            "time": "2019-12-31T17:51:15+00:00"
+        },
+        {
+            "name": "laminas/laminas-uri",
+            "version": "2.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-uri.git",
+                "reference": "6be8ce19622f359b048ce4faebf1aa1bca73a7ff"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-uri/zipball/6be8ce19622f359b048ce4faebf1aa1bca73a7ff",
+                "reference": "6be8ce19622f359b048ce4faebf1aa1bca73a7ff",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-escaper": "^2.5",
+                "laminas/laminas-validator": "^2.10",
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "replace": {
+                "zendframework/zend-uri": "self.version"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7.x-dev",
+                    "dev-develop": "2.8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Uri\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "A component that aids in manipulating and validating » Uniform Resource Identifiers (URIs)",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "uri"
+            ],
+            "time": "2019-12-31T17:56:00+00:00"
+        },
+        {
+            "name": "laminas/laminas-validator",
+            "version": "2.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-validator.git",
+                "reference": "93593684e70b8ed1e870cacd34ca32b0c0ace185"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/93593684e70b8ed1e870cacd34ca32b0c0ace185",
+                "reference": "93593684e70b8ed1e870cacd34ca32b0c0ace185",
+                "shasum": ""
+            },
+            "require": {
+                "container-interop/container-interop": "^1.1",
+                "laminas/laminas-stdlib": "^3.2.1",
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^7.1"
+            },
+            "replace": {
+                "zendframework/zend-validator": "^2.13.0"
+            },
+            "require-dev": {
+                "laminas/laminas-cache": "^2.6.1",
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-config": "^2.6",
+                "laminas/laminas-db": "^2.7",
+                "laminas/laminas-filter": "^2.6",
+                "laminas/laminas-http": "^2.5.4",
+                "laminas/laminas-i18n": "^2.6",
+                "laminas/laminas-math": "^2.6",
+                "laminas/laminas-servicemanager": "^2.7.5 || ^3.0.3",
+                "laminas/laminas-session": "^2.8",
+                "laminas/laminas-uri": "^2.5",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.2",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.0"
+            },
+            "suggest": {
+                "laminas/laminas-db": "Laminas\\Db component, required by the (No)RecordExists validator",
+                "laminas/laminas-filter": "Laminas\\Filter component, required by the Digits validator",
+                "laminas/laminas-i18n": "Laminas\\I18n component to allow translation of validation error messages",
+                "laminas/laminas-i18n-resources": "Translations of validator messages",
+                "laminas/laminas-math": "Laminas\\Math component, required by the Csrf validator",
+                "laminas/laminas-servicemanager": "Laminas\\ServiceManager component to allow using the ValidatorPluginManager and validator chains",
+                "laminas/laminas-session": "Laminas\\Session component, ^2.8; required by the Csrf validator",
+                "laminas/laminas-uri": "Laminas\\Uri component, required by the Uri and Sitemap\\Loc validators",
+                "psr/http-message": "psr/http-message, required when validating PSR-7 UploadedFileInterface instances via the Upload and UploadFile validators"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.13.x-dev",
+                    "dev-develop": "2.14.x-dev"
+                },
+                "laminas": {
+                    "component": "Laminas\\Validator",
+                    "config-provider": "Laminas\\Validator\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Validator\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Validation classes for a wide range of domains, and the ability to chain validators to create complex validation criteria",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "validator"
+            ],
+            "time": "2020-03-31T18:57:01+00:00"
+        },
+        {
+            "name": "laminas/laminas-view",
+            "version": "2.11.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-view.git",
+                "reference": "3bbb2e94287383604c898284a18d2d06cf17301e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-view/zipball/3bbb2e94287383604c898284a18d2d06cf17301e",
+                "reference": "3bbb2e94287383604c898284a18d2d06cf17301e",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-eventmanager": "^2.6.2 || ^3.0",
+                "laminas/laminas-json": "^2.6.1 || ^3.0",
+                "laminas/laminas-loader": "^2.5",
+                "laminas/laminas-stdlib": "^2.7 || ^3.0",
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "replace": {
+                "zendframework/zend-view": "self.version"
+            },
+            "require-dev": {
+                "laminas/laminas-authentication": "^2.5",
+                "laminas/laminas-cache": "^2.6.1",
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-config": "^2.6",
+                "laminas/laminas-console": "^2.6",
+                "laminas/laminas-escaper": "^2.5",
+                "laminas/laminas-feed": "^2.7",
+                "laminas/laminas-filter": "^2.6.1",
+                "laminas/laminas-http": "^2.5.4",
+                "laminas/laminas-i18n": "^2.6",
+                "laminas/laminas-log": "^2.7",
+                "laminas/laminas-modulemanager": "^2.7.1",
+                "laminas/laminas-mvc": "^2.7.14 || ^3.0",
+                "laminas/laminas-navigation": "^2.5",
+                "laminas/laminas-paginator": "^2.5",
+                "laminas/laminas-permissions-acl": "^2.6",
+                "laminas/laminas-router": "^3.0.1",
+                "laminas/laminas-serializer": "^2.6.1",
+                "laminas/laminas-servicemanager": "^2.7.5 || ^3.0.3",
+                "laminas/laminas-session": "^2.8.1",
+                "laminas/laminas-uri": "^2.5",
+                "phpunit/phpunit": "^5.7.15 || ^6.0.8"
+            },
+            "suggest": {
+                "laminas/laminas-authentication": "Laminas\\Authentication component",
+                "laminas/laminas-escaper": "Laminas\\Escaper component",
+                "laminas/laminas-feed": "Laminas\\Feed component",
+                "laminas/laminas-filter": "Laminas\\Filter component",
+                "laminas/laminas-http": "Laminas\\Http component",
+                "laminas/laminas-i18n": "Laminas\\I18n component",
+                "laminas/laminas-mvc": "Laminas\\Mvc component",
+                "laminas/laminas-mvc-plugin-flashmessenger": "laminas-mvc-plugin-flashmessenger component, if you want to use the FlashMessenger view helper with laminas-mvc versions 3 and up",
+                "laminas/laminas-navigation": "Laminas\\Navigation component",
+                "laminas/laminas-paginator": "Laminas\\Paginator component",
+                "laminas/laminas-permissions-acl": "Laminas\\Permissions\\Acl component",
+                "laminas/laminas-servicemanager": "Laminas\\ServiceManager component",
+                "laminas/laminas-uri": "Laminas\\Uri component"
+            },
+            "bin": [
+                "bin/templatemap_generator.php"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.11.x-dev",
+                    "dev-develop": "2.12.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\View\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Flexible view layer supporting and providing multiple view layers, helpers, and more",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "view"
+            ],
+            "time": "2019-12-31T18:03:30+00:00"
+        },
+        {
+            "name": "laminas/laminas-zendframework-bridge",
+            "version": "1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
+                "reference": "fcd87520e4943d968557803919523772475e8ea3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/fcd87520e4943d968557803919523772475e8ea3",
+                "reference": "fcd87520e4943d968557803919523772475e8ea3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.1",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev",
+                    "dev-develop": "1.1.x-dev"
+                },
+                "laminas": {
+                    "module": "Laminas\\ZendFrameworkBridge"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/autoload.php"
+                ],
+                "psr-4": {
+                    "Laminas\\ZendFrameworkBridge\\": "src//"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Alias legacy ZF class names to Laminas Project equivalents.",
+            "keywords": [
+                "ZendFramework",
+                "autoloading",
+                "laminas",
+                "zf"
+            ],
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2020-05-20T16:45:56+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "time": "2017-02-14T16:28:37+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "dev",
+    "stability-flags": [],
+    "prefer-stable": true,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
+}

--- a/integration/updates/non-migrated-package-to-migrated-package/composer.sh
+++ b/integration/updates/non-migrated-package-to-migrated-package/composer.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+composer install --no-interaction --working-dir=$1
+composer require bar/baz:^2.0 --no-interaction --working-dir=$1
+composer validate --no-check-all --working-dir=$1

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -9,6 +9,9 @@
     <exclude-pattern>test/*/TestAsset/</exclude-pattern>
 
     <rule ref="WebimpressCodingStandard.PHP.DeclareStrictTypes">
-        <exclude-pattern>src/DependencyRewriterPlugin.php</exclude-pattern>
+        <exclude-pattern>src/*</exclude-pattern>
+    </rule>
+    <rule ref="WebimpressCodingStandard.Functions.NullableTypehint">
+        <exclude-pattern>src/*</exclude-pattern>
     </rule>
 </ruleset>

--- a/src/ComposerFile.php
+++ b/src/ComposerFile.php
@@ -1,0 +1,341 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-dependency-plugin for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-dependency-plugin/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-dependency-plugin/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Laminas\DependencyPlugin;
+
+use Composer\Json\JsonFile;
+use Composer\Package\Link;
+use Composer\Package\PackageInterface;
+use Composer\Package\Version\VersionParser;
+use Composer\Semver\Constraint\ConstraintInterface;
+use function array_keys;
+use function array_map;
+use function array_replace_recursive;
+use function in_array;
+use function ksort;
+
+final class ComposerFile
+{
+    /**
+     * @var array
+     */
+    private $composerDefinition;
+
+    /**
+     * @var JsonFile
+     */
+    private $file;
+
+    /**
+     * Flag to see if we have to write the file back to filesystem or not.
+     * @var bool
+     */
+    private $dirty = false;
+
+    public function __construct(JsonFile $file)
+    {
+        $this->file = $file;
+        $definition = $file->read();
+        assert(is_array($definition));
+        $this->composerDefinition = $definition;
+    }
+
+    /**
+     * @param string $package
+     * @param string $packageReplacement
+     * @param string $packageWhyZendPackageIsInstalled
+     * @parma string $versionConstraint
+     * @return self
+     */
+    public function withZendPackageReplacement(
+        $package,
+        $packageReplacement,
+        $packageWhyZendPackageIsInstalled,
+        $versionConstraint
+    ) {
+        $instance = clone $this;
+
+        $dev = isset($instance->composerDefinition['require-dev'][$packageWhyZendPackageIsInstalled]);
+
+        $key = $dev ? 'require-dev' : 'require';
+        $instance->composerDefinition[$key][$packageReplacement] = $versionConstraint;
+        unset($instance->composerDefinition[$key][$package]);
+
+        return $instance;
+    }
+
+    public function store()
+    {
+        if (!$this->dirty) {
+            return;
+        }
+
+        $definition = $this->sortPackages($this->composerDefinition);
+        $definition = $this->cleanup($definition);
+        $this->file->write($definition);
+        $this->dirty = false;
+    }
+
+    /**
+     * @return array
+     */
+    private function sortPackages(array $composerDefinition)
+    {
+        if (! isset($composerDefinition['config']['sort-packages'])
+            || $composerDefinition['config']['sort-packages'] === false
+        ) {
+            return $composerDefinition;
+        }
+
+        if (isset($composerDefinition['extra']['laminas-migration']['nonMigratedPackages'])) {
+            $nonMigratedPackages = $composerDefinition['extra']['laminas-migration']['nonMigratedPackages'];
+            foreach ($nonMigratedPackages as $package => $packages) {
+                ksort($packages);
+                $nonMigratedPackages[$package] = $packages;
+            }
+
+            ksort($nonMigratedPackages);
+            $composerDefinition['extra']['laminas-migration']['nonMigratedPackages'] = $nonMigratedPackages;
+        }
+
+        if (isset($composerDefinition['require'])) {
+            ksort($composerDefinition['require']);
+        }
+
+        if (isset($composerDefinition['require-dev'])) {
+            ksort($composerDefinition['require-dev']);
+        }
+
+        return $composerDefinition;
+    }
+
+    /**
+     * @param Link[] $packageLinksWhichRequireZendPackage
+     * @return self
+     */
+    public function rememberNonMigratedPackages(array $packageLinksWhichRequireZendPackage)
+    {
+        $instance = clone $this;
+        $composerDefinition = $this->composerDefinition;
+
+        foreach ($packageLinksWhichRequireZendPackage as $packageLink) {
+            $composerDefinition = $this->rememberPackage(
+                $composerDefinition,
+                $packageLink->getSource(),
+                $packageLink->getTarget(),
+                $packageLink->getPrettyConstraint()
+            );
+        }
+
+        $instance->composerDefinition = $composerDefinition;
+
+        return $instance;
+    }
+
+    /**
+     * @param array  $composerDefinition
+     * @param string $packageNameWhichRequiresZendPackage
+     * @param string $mostOuterZendPackageReplacement
+     * @param string $versionConstraint
+     * @return array
+     */
+    private function rememberPackage(
+        array $composerDefinition,
+        $packageNameWhichRequiresZendPackage,
+        $mostOuterZendPackageReplacement,
+        $versionConstraint
+    ) {
+        $definition = [
+            'extra' => [
+                'laminas-migration' => [
+                    'nonMigratedPackages' => [
+                        $packageNameWhichRequiresZendPackage => [
+                            $mostOuterZendPackageReplacement => $versionConstraint,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        return array_replace_recursive($composerDefinition, $definition);
+    }
+
+    /**
+     * Returns all packages which were added to composer.json requirements to replace zend-packages.
+     * @return array
+     */
+    public function getZendPackagesWhichWereReplacedByLaminasPackages(PackageInterface $package)
+    {
+        $packages = $this->extractNonMigratedPackages($this->composerDefinition);
+        if (!isset($packages[$package->getName()])) {
+            return [];
+        }
+
+        return array_keys($packages[$package->getName()]);
+    }
+
+    /**
+     * In case a package is being uninstalled, we can just forget it.
+     * @param string $package
+     * @return self
+     */
+    public function forgetNonMigratedPackage($package)
+    {
+        $instance = clone $this;
+        unset($instance->composerDefinition['extra']['laminas-migration']['nonMigratedPackages'][$package]);
+
+        return $instance;
+    }
+
+    public function withoutPackageRequirements(array $packagesToRemove)
+    {
+        if (!$packagesToRemove) {
+            return $this;
+        }
+
+        $instance = clone $this;
+        $composerDefinition = $instance->composerDefinition;
+
+        $nonMigratedPackages = $instance->extractNonMigratedPackages($composerDefinition);
+        foreach ($packagesToRemove as $zendPackageName => $laminasPackageName) {
+            unset(
+                $composerDefinition['require'][$laminasPackageName],
+                $composerDefinition['require-dev'][$laminasPackageName]
+            );
+
+            foreach ($nonMigratedPackages as $nonMigratedPackage => $nonMigratedPackageDependencies) {
+                if (!isset($nonMigratedPackageDependencies[$zendPackageName])) {
+                    continue;
+                }
+
+                unset($nonMigratedPackageDependencies[$zendPackageName]);
+                if (empty($nonMigratedPackageDependencies)) {
+                    unset($nonMigratedPackages[$nonMigratedPackage]);
+                }
+            }
+        }
+
+        $instance->composerDefinition = $composerDefinition;
+        $instance->setNonMigratedPackages($nonMigratedPackages);
+
+        return $instance;
+    }
+
+    /**
+     * @return array
+     */
+    private function extractNonMigratedPackages(array $definition)
+    {
+        if (!isset($definition['extra']['laminas-migration']['nonMigratedPackages'])) {
+            return [];
+        }
+
+        return $definition['extra']['laminas-migration']['nonMigratedPackages'];
+    }
+
+    private function setNonMigratedPackages(array $nonMigratedPackages)
+    {
+        $this->composerDefinition['extra']['laminas-migration']['nonMigratedPackages'] = $nonMigratedPackages;
+    }
+
+    private function cleanup(array $composerDefinition)
+    {
+        $nonMigratedPackages = $this->extractNonMigratedPackages($composerDefinition);
+        if (!$nonMigratedPackages) {
+            unset($composerDefinition['extra']['laminas-migration']);
+        }
+
+        if (empty($composerDefinition['extra'])) {
+            unset($composerDefinition['extra']);
+        }
+
+        return $composerDefinition;
+    }
+
+    public function updateNonMigratedPackages(PackageInterface $package)
+    {
+        $nonMigratedPackages = $this->extractNonMigratedPackages($this->composerDefinition);
+        if (!isset($nonMigratedPackages[$package->getName()])) {
+            return $this;
+        }
+
+        $instance = clone $this;
+        $zendPackages = $nonMigratedPackages[$package->getName()];
+
+        $packageRequirements = array_map(static function (Link $link) {
+            return $link->getTarget();
+        }, $package->getRequires());
+
+
+        foreach ($zendPackages as $zendPackage => $constraint) {
+            if (in_array($zendPackages, $packageRequirements, true)) {
+                continue;
+            }
+
+            unset($zendPackages[$zendPackage]);
+        }
+
+        if (!$zendPackages) {
+            unset($nonMigratedPackages[$package->getName()]);
+            $instance->setNonMigratedPackages($nonMigratedPackages);
+            return $instance;
+        }
+
+        $nonMigratedPackages[$package->getName()] = $nonMigratedPackages;
+        $instance->setNonMigratedPackages($nonMigratedPackages);
+        return $instance;
+    }
+
+    public function getNextConstraintFromNonMigratedPackages($zendPackage)
+    {
+        $nonMigratedPackages = $this->extractNonMigratedPackages($this->composerDefinition);
+
+        $constraints = [];
+        foreach ($nonMigratedPackages as $packageName => $zendPackages) {
+            if (!isset($zendPackages[$zendPackage])) {
+                continue;
+            }
+
+            $constraints[$packageName] = $zendPackages[$zendPackage];
+        }
+
+        if (!$constraints) {
+            return '';
+        }
+
+        $parser = new VersionParser();
+        /**
+         * @var ConstraintInterface[] $constraints
+         * @psalm-var array<string,ConstraintInterface> $constraints
+         */
+        $constraints = array_map([$parser, 'parseConstraints'], $constraints);
+        $lowest = key($constraints);
+        foreach ($constraints as $packageName => $constraint) {
+            if ($packageName === $lowest) {
+                continue;
+            }
+
+            $lowestConstraint = $constraints[$lowest];
+
+            $from = $constraint->getLowerBound()->getVersion();
+            $to = $lowestConstraint->getLowerBound()->getVersion();
+            if (VersionParser::isUpgrade($from, $to)) {
+                continue;
+            }
+
+            $lowest = $packageName;
+        }
+
+        return sprintf('%s:%s', $lowest, $constraints[$lowest]->getPrettyString());
+    }
+
+    public function __clone()
+    {
+        $this->dirty = true;
+    }
+}

--- a/src/ComposerInstallationDetails.php
+++ b/src/ComposerInstallationDetails.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-dependency-plugin for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-dependency-plugin/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-dependency-plugin/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Laminas\DependencyPlugin;
+
+use Composer\Package\Link;
+
+final class ComposerInstallationDetails
+{
+    /**
+     * Marker to see if the package is required by a dev dependency.
+     *
+     * @var bool
+     */
+    public $dev;
+
+    /**
+     * Zend package name which is required by a 3rd party library.
+     * This package probably replaces other packages if required.
+     *
+     * @var string
+     */
+    public $mostOuterZendPackageName;
+
+    /**
+     * Version constraint which we have to use to put into composer.json
+     *
+     * @var string
+     */
+    public $versionConstraint;
+
+    /**
+     * Packages which are also replaced if we require the package inside
+     * {@see ComposerInstallationDetails::$mostOuterZendPackageName}
+     *
+     * @var array
+     */
+    public $packagesWhichWillBeReplaced;
+
+    /**
+     * Contains the package name of the 3rd-party library which requires the
+     * {@see ComposerInstallationDetails::$mostOuterZendPackageName}.
+     *
+     * @var Link[]
+     */
+    public $packageLinksWhichRequireZendPackage;
+
+    /**
+     * @param bool $dev
+     * @param string $mostOuterZendPackageName
+     * @param string $versionConstraint
+     * @param array  $packagesWhichWillBeReplaced
+     * @param Link[] $packageLinksWhichRequireZendPackage
+     */
+    private function __construct(
+        $dev,
+        $mostOuterZendPackageName,
+        $versionConstraint,
+        array $packagesWhichWillBeReplaced,
+        array $packageLinksWhichRequireZendPackage
+    ) {
+        $this->dev = $dev;
+        $this->mostOuterZendPackageName = $mostOuterZendPackageName;
+        $this->versionConstraint = $versionConstraint;
+        $this->packagesWhichWillBeReplaced = $packagesWhichWillBeReplaced;
+        $this->packageLinksWhichRequireZendPackage = $packageLinksWhichRequireZendPackage;
+    }
+
+    /**
+     * @param bool $dev
+     * @param string $mostOuterZendPackageName
+     * @param string $versionConstraint
+     * @param array  $packagesWhichWillBeReplaced
+     * @param Link[] $packageLinksWhichRequireZendPackage
+     * @return self
+     */
+    public static function create(
+        $dev,
+        $mostOuterZendPackageName,
+        $versionConstraint,
+        array $packagesWhichWillBeReplaced,
+        array $packageLinksWhichRequireZendPackage
+    ) {
+        return new self(
+            $dev,
+            $mostOuterZendPackageName,
+            $versionConstraint,
+            $packagesWhichWillBeReplaced,
+            $packageLinksWhichRequireZendPackage
+        );
+    }
+}

--- a/src/DependencyRewriterPlugin.php
+++ b/src/DependencyRewriterPlugin.php
@@ -9,23 +9,47 @@
 namespace Laminas\DependencyPlugin;
 
 use Composer\Composer;
+use Composer\Console\Application;
 use Composer\DependencyResolver\Operation;
 use Composer\EventDispatcher\EventSubscriberInterface;
-use Composer\Installer\InstallerEvent;
-use Composer\Installer\InstallerEvents;
+use Composer\Factory;
 use Composer\Installer\PackageEvent;
 use Composer\Installer\PackageEvents;
 use Composer\IO\IOInterface;
+use Composer\Json\JsonFile;
+use Composer\Package\CompletePackageInterface;
+use Composer\Package\Link;
 use Composer\Package\PackageInterface;
+use Composer\Package\Version\VersionParser;
 use Composer\Plugin\PluginEvents;
 use Composer\Plugin\PluginInterface;
 use Composer\Plugin\PreCommandRunEvent;
-use ReflectionProperty;
-
+use Composer\Repository\ArrayRepository;
+use Composer\Repository\CompositeRepository;
+use Composer\Repository\InstalledRepository;
+use Composer\Repository\PlatformRepository;
+use Composer\Repository\RepositoryInterface;
+use Composer\Repository\RootPackageRepository;
+use Composer\Script\Event;
+use Composer\Script\ScriptEvents;
+use Composer\Semver\Constraint\ConstraintInterface;
+use RuntimeException;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+use function array_filter;
+use function array_flip;
+use function array_keys;
 use function array_map;
+use function array_merge;
 use function array_shift;
+use function array_unique;
+use function array_values;
+use function assert;
+use function class_exists;
 use function count;
 use function get_class;
+use function getcwd;
+use function implode;
 use function in_array;
 use function preg_match;
 use function preg_split;
@@ -52,15 +76,62 @@ class DependencyRewriterPlugin implements EventSubscriberInterface, PluginInterf
     private $io;
 
     /**
+     * @var array
+     */
+    private $packageReplacementsFound = [];
+
+    /**
+     * @var callable
+     */
+    private $applicationFactory;
+
+    /**
+     * @var null|RepositoryInterface
+     */
+    private $installedRepo;
+
+    /**
+     * @var ComposerFile
+     */
+    private $composerFile;
+
+    /**
+     * @var array
+     * @psalm-var array<string,list<string>>
+     */
+    private $nonMigratedPackageRemovals = [];
+
+    /**
+     * @var array
+     * @psalm-var array<string,string>
+     */
+    private $laminasPackageRemovals = [];
+
+    /**
+     * @var array
+     * @psalm-var array<string,PackageInterface>
+     */
+    private $nonMigratedPackageUpdates = [];
+
+    public function __construct(callable $applicationFactory = null)
+    {
+        $this->applicationFactory = $applicationFactory ?: static function () {
+            return new Application();
+        };
+    }
+
+    /**
      * @return array Returns in following format:
      *     <string> => array<string, int>
      */
     public static function getSubscribedEvents()
     {
         return [
-            InstallerEvents::PRE_DEPENDENCIES_SOLVING => ['onPreDependenciesSolving', 1000],
-            PackageEvents::PRE_PACKAGE_INSTALL => ['onPrePackageInstall', 1000],
             PluginEvents::PRE_COMMAND_RUN => ['onPreCommandRun', 1000],
+            PackageEvents::PRE_PACKAGE_INSTALL => ['onPrePackageInstall', 1000],
+            PackageEvents::PRE_PACKAGE_UPDATE => ['onPrePackageInstall', 1000],
+            ScriptEvents::POST_AUTOLOAD_DUMP => ['onPostAutoloadDump', -1000],
+            PackageEvents::POST_PACKAGE_UNINSTALL => ['onPostPackageUninstall', 1000],
         ];
     }
 
@@ -94,59 +165,6 @@ class DependencyRewriterPlugin implements EventSubscriberInterface, PluginInterf
     }
 
     /**
-     * Replace ZF packages present in the composer.json during install or
-     * update operations.
-     *
-     * When the `composer.json` has references to ZF packages, and the user
-     * requests an `install` or `update`, this method will rewrite any such
-     * packages to their Laminas equivalents prior to attempting to resolve
-     * dependencies, ensuring the Laminas versions are installed.
-     */
-    public function onPreDependenciesSolving(InstallerEvent $event)
-    {
-        $this->output(sprintf('<info>In %s</info>', __METHOD__), IOInterface::DEBUG);
-        $request = $event->getRequest();
-        $jobs = $request->getJobs();
-        $changes = false;
-
-        foreach ($jobs as $index => $job) {
-            if (! isset($job['cmd']) || ! in_array($job['cmd'], ['install', 'update'], true)) {
-                continue;
-            }
-
-            if (! isset($job['packageName'])) {
-                continue;
-            }
-
-            $name = $job['packageName'];
-            if (! $this->isZendPackage($name)) {
-                continue;
-            }
-
-            $replacementName = $this->transformPackageName($name);
-            if ($replacementName === $name) {
-                continue;
-            }
-
-            $this->output(sprintf(
-                '<info>Replacing package "%s" with package "%s"</info>',
-                $name,
-                $replacementName
-            ), IOInterface::VERBOSE);
-
-            $job['packageName'] = $replacementName;
-            $jobs[$index] = $job;
-            $changes = true;
-        }
-
-        if (! $changes) {
-            return;
-        }
-
-        $this->updateProperty($request, 'jobs', $jobs);
-    }
-
-    /**
      * Ensure nested dependencies on ZF packages install equivalent Laminas packages.
      *
      * When a 3rd party package has dependencies on ZF packages, this method
@@ -155,6 +173,10 @@ class DependencyRewriterPlugin implements EventSubscriberInterface, PluginInterf
      */
     public function onPrePackageInstall(PackageEvent $event)
     {
+        if (! $event->isDevMode()) {
+            return;
+        }
+
         $this->output(sprintf('<info>In %s</info>', __METHOD__), IOInterface::DEBUG);
         $operation = $event->getOperation();
 
@@ -171,50 +193,118 @@ class DependencyRewriterPlugin implements EventSubscriberInterface, PluginInterf
                     '<info>Exiting; operation of type %s not supported</info>',
                     get_class($operation)
                 ), IOInterface::DEBUG);
+
                 return;
         }
 
-        $name = $package->getName();
-        if (! $this->isZendPackage($name)) {
+        $composerFile = $this->createComposerFile();
+        $zendPackages = $composerFile->getZendPackagesWhichWereReplacedByLaminasPackages($package);
+
+        if ($zendPackages) {
+            $this->nonMigratedPackageUpdates[$package->getName()] = $package;
+        }
+
+        $replacementName = $this->extractReplacementName($package);
+        if ($replacementName === '') {
             // Nothing to do
             $this->output(sprintf(
                 '<info>Exiting; package "%s" does not have a replacement</info>',
-                $name
+                $package->getName()
             ), IOInterface::DEBUG);
+
             return;
+        }
+
+        $constraint = $package->getPrettyVersion();
+        $this->output(sprintf(
+            '<info>Found replacement for package %s (%s), using version %s</info>',
+            $package->getName(),
+            $replacementName,
+            $constraint
+        ), IOInterface::VERBOSE);
+
+        $this->packageReplacementsFound[$package->getName()] = [$replacementName, $constraint];
+    }
+
+    /**
+     * @return string
+     */
+    private function extractReplacementName(PackageInterface $package)
+    {
+        $name = $package->getName();
+        if (! $this->isZendPackage($name)) {
+            return '';
+        }
+
+        if ($package instanceof CompletePackageInterface) {
+            $replacementName = $package->getReplacementPackage();
+            if ($replacementName !== null) {
+                return $replacementName;
+            }
         }
 
         $replacementName = $this->transformPackageName($name);
-        if ($replacementName === $name) {
-            // Nothing to do
-            $this->output(sprintf(
-                '<info>Exiting; while package "%s" is a ZF package, it does not have a replacement</info>',
-                $name
-            ), IOInterface::DEBUG);
+        if ($replacementName !== $name) {
+            return $replacementName;
+        }
+
+        return '';
+    }
+
+    public function onPostAutoloadDump(Event $event)
+    {
+        $composerFile = $this->createComposerFile();
+        try {
+            $composerFile = $this->handlePackageInstallationsAndUpdates(
+                $composerFile,
+                $this->packageReplacementsFound
+            );
+            $composerFile = $this->handlePackageUpdates(
+                $composerFile,
+                $this->nonMigratedPackageUpdates
+            );
+
+            $composerFile = $this->handlePackageUninstallations(
+                $composerFile,
+                $this->nonMigratedPackageRemovals,
+                $this->laminasPackageRemovals
+            );
+        } catch (MigrationFailedException $exception) {
+            $this->output(sprintf('<error>%s</error>', $exception->getMessage()));
             return;
         }
 
-        $version = $package->getVersion();
-        $replacementPackage = $this->composer->getRepositoryManager()->findPackage($replacementName, $version);
+        $composerFile->store();
+    }
 
-        if ($replacementPackage === null) {
-            // No matching replacement package found
-            $this->output(sprintf(
-                '<info>Exiting; no replacement package found for package "%s" with version %s</info>',
-                $replacementName,
-                $version
-            ), IOInterface::DEBUG);
+    public function onPostPackageUninstall(PackageEvent $event)
+    {
+        if (! $event->isDevMode()) {
             return;
         }
 
-        $this->output(sprintf(
-            '<info>Replacing package %s with package %s, using version %s</info>',
-            $name,
-            $replacementName,
-            $version
-        ), IOInterface::VERBOSE);
+        $operation = $event->getOperation();
+        if (!$operation instanceof Operation\UninstallOperation) {
+            return;
+        }
 
-        $this->replacePackageInOperation($replacementPackage, $operation);
+        $package = $operation->getPackage();
+
+        $composerFile = $this->createComposerFile();
+
+        $laminasPackages = $composerFile->getZendPackagesWhichWereReplacedByLaminasPackages($package);
+
+        if ($laminasPackages) {
+            $this->nonMigratedPackageRemovals[$package->getName()] = $laminasPackages;
+            return;
+        }
+
+        $zendEquivalent = $this->extractZendEquivalent($package);
+        if ($zendEquivalent === '') {
+            return;
+        }
+
+        $this->laminasPackageRemovals[$package->getName()] = $zendEquivalent;
     }
 
     /**
@@ -308,29 +398,9 @@ class DependencyRewriterPlugin implements EventSubscriberInterface, PluginInterf
                 if (preg_match('#^zendframework/zend-(?<name>.*)$#', $name, $matches)) {
                     return sprintf('laminas/laminas-%s', $matches['name']);
                 }
+
                 return $name;
         }
-    }
-
-    private function replacePackageInOperation(PackageInterface $replacement, Operation\OperationInterface $operation)
-    {
-        $this->updateProperty(
-            $operation,
-            $operation instanceof Operation\UpdateOperation ? 'targetPackage' : 'package',
-            $replacement
-        );
-    }
-
-    /**
-     * @param object $object
-     * @param string $property
-     * @param mixed $value
-     */
-    private function updateProperty($object, $property, $value)
-    {
-        $r = new ReflectionProperty($object, $property);
-        $r->setAccessible(true);
-        $r->setValue($object, $value);
     }
 
     /**
@@ -340,5 +410,557 @@ class DependencyRewriterPlugin implements EventSubscriberInterface, PluginInterf
     private function output($message, $verbosity = IOInterface::NORMAL)
     {
         $this->io->write($message, $newline = true, $verbosity);
+    }
+
+    public function deactivate(Composer $composer, IOInterface $io)
+    {
+    }
+
+    public function uninstall(Composer $composer, IOInterface $io)
+    {
+    }
+
+    /**
+     * @param string $question
+     * @return bool
+     */
+    private function confirm($question)
+    {
+        return $this->io->askConfirmation(sprintf('<question>%s</question>', $question));
+    }
+
+    /**
+     * @param bool $lockPackageVersion
+     * @param array $packageReplacements
+     * @return ComposerFile
+     */
+    private function replacePackagesInDefinition(
+        ComposerFile $composerFile,
+        array $packageReplacements,
+        $lockPackageVersion
+    ) {
+        $packageAlreadyReplaced = [];
+        $packageReplacementMap = [];
+
+        foreach ($packageReplacements as $package => list($mostOuterZendPackageReplacement)) {
+            $packageReplacementMap[$mostOuterZendPackageReplacement] = $package;
+            $packageAlreadyReplaced[$package] = false;
+        }
+
+        foreach ($packageReplacements as $package => list($packageReplacement, $installedPackageVersion)) {
+            if ($packageAlreadyReplaced[$package]) {
+                continue;
+            }
+
+            $details = $this->askComposerWhyPackageIsInstalled(
+                $package,
+                $installedPackageVersion,
+                $lockPackageVersion
+            );
+
+            list($mostOuterZendPackageReplacement) = $packageReplacements[$details->mostOuterZendPackageName];
+
+            $composerFile = $composerFile->withZendPackageReplacement(
+                $package,
+                $mostOuterZendPackageReplacement,
+                $details->packageLinksWhichRequireZendPackage[0]->getSource(),
+                $details->versionConstraint
+            );
+
+            $packageAlreadyReplaced[$details->mostOuterZendPackageName] = true;
+
+            foreach ($details->packagesWhichWillBeReplaced as $packageWhichWillBeReplacedAswell) {
+                if (! isset($packageReplacementMap[$packageWhichWillBeReplacedAswell])) {
+                    continue;
+                }
+
+                $packageName = $packageReplacementMap[$packageWhichWillBeReplacedAswell];
+                $packageAlreadyReplaced[$packageName] = true;
+            }
+
+            if (!$lockPackageVersion) {
+                $this->output(sprintf(
+                    'Adding "%s" to `composer.json` dependencies to replace "%s"',
+                    $mostOuterZendPackageReplacement,
+                    $details->mostOuterZendPackageName
+                ));
+            }
+
+            $composerFile = $composerFile->rememberNonMigratedPackages(
+                $details->packageLinksWhichRequireZendPackage
+            );
+        }
+
+        return $composerFile;
+    }
+
+    /**
+     * @param string[] $packagesToUpdate
+     * @return int
+     */
+    private function updateLockFile(array $packagesToUpdate)
+    {
+        $applicationFactory = $this->applicationFactory;
+        $application = $applicationFactory();
+        $output = ! $this->io->isVerbose() ? new NullOutput() : null;
+        $application->setAutoExit(false);
+
+        $input = [
+            'command' => 'update',
+            '--lock' => empty($packagesToUpdate),
+            '--no-plugins' => true,
+            '--no-scripts' => true,
+            '--working-dir' => getcwd(),
+            'packages' => $packagesToUpdate,
+        ];
+
+        return $application->run(new ArrayInput($input), $output);
+    }
+
+    /**
+     * In case of `lock`, we want to provide a constraint to ensure we update to the most recent laminas package
+     * matching the current version.
+     * There are some packages which received version fixes (no changes, just some fixes) after migrated to laminas.
+     * Those packages have `p1` postfix.
+     * {@see https://github.com/laminas/laminas-diactoros/compare/2.2.1...2.2.1p1 Example for fixed version}
+     *
+     * @param string $package
+     * @param string $version
+     * @param bool $lock
+     * @return ComposerInstallationDetails
+     * @throws RuntimeException if no dependencies could be found.
+     */
+    private function askComposerWhyPackageIsInstalled($package, $version, $lock)
+    {
+        $composer = $this->composer;
+        $repository = $this->createInstalledPackagesRepository($composer);
+        $rootPackage = $composer->getPackage();
+        $devRequires = $rootPackage->getDevRequires();
+
+        $versionParser = new VersionParser();
+        $constraint = $versionParser->parseConstraints($version);
+        $this->output(sprintf('Searching for %s', $package), IOInterface::DEBUG);
+
+        $results = $repository->getDependents(
+            $package,
+            $constraint
+        );
+
+        if (! $results) {
+            throw new RuntimeException(sprintf(
+                'Could not determine dependency graph for package %s;'
+                . ' need that graph to put it into the proper `require` or `require-dev` requirements...',
+                $package
+            ));
+        }
+
+        $packagesWhichWillBeReplaced = $this->generatePackagesWhichWillBeReplaced($results);
+        $mostOuterZendPackageLink = $this->extractMostOuterZendPackage($results);
+        $mostOuterZendPackageName = $package;
+        $mostOuterZendPackageVersion = $version;
+
+        if ($mostOuterZendPackageLink !== null) {
+            $mostOuterZendPackageName = $mostOuterZendPackageLink->getSource();
+        }
+
+        $this->output(sprintf(
+            'Found the following packages which will be replaced by requiring %s: %s',
+            $mostOuterZendPackageName,
+            implode(', ', $packagesWhichWillBeReplaced)
+        ), IOInterface::DEBUG);
+
+        $packageLinksWhichRequireZendPackage = array_map(
+            static function (array $result) {
+                return $result[1];
+            },
+            $repository->getDependents($mostOuterZendPackageName)
+        );
+
+        $packageWhichRequiresZendPackage = $packageLinksWhichRequireZendPackage[0];
+
+        assert($packageWhichRequiresZendPackage instanceof Link);
+
+        $this->output(sprintf(
+            'Package "%s" requires zend-package "%s" with constraint "%s"',
+            $packageWhichRequiresZendPackage->getSource(),
+            $mostOuterZendPackageName,
+            $packageWhichRequiresZendPackage->getPrettyConstraint()
+        ), IOInterface::DEBUG);
+
+        $mostOuterZendPackageConstraint = $packageWhichRequiresZendPackage->getConstraint();
+        assert($mostOuterZendPackageConstraint instanceof ConstraintInterface);
+        if ($mostOuterZendPackageName !== $package) {
+            $mostOuterZendPackageVersion = $repository
+                ->findPackage(
+                    $mostOuterZendPackageName,
+                    $packageWhichRequiresZendPackage->getConstraint()
+                )
+                ->getPrettyVersion();
+        }
+
+        $packageNameWhichRequiresZendPackage = $packageWhichRequiresZendPackage->getSource();
+        $dev = isset($devRequires[$packageNameWhichRequiresZendPackage]);
+
+        return ComposerInstallationDetails::create(
+            $dev,
+            $mostOuterZendPackageName,
+            $lock ? sprintf('~%s.0', $mostOuterZendPackageVersion) : $mostOuterZendPackageConstraint->getPrettyString(),
+            $packagesWhichWillBeReplaced,
+            $packageLinksWhichRequireZendPackage
+        );
+    }
+
+    /**
+     * @return null|Link
+     */
+    private function extractMostOuterZendPackage(array $results)
+    {
+        $latest = null;
+
+        /**
+         * @var PackageInterface $package
+         * @var Link $link
+         * @var array $children
+         */
+        foreach ($results as list($package, $link, $children)) {
+            $latest = $this->extractMostOuterZendPackage($children);
+            if (! $this->extractReplacementName($package)) {
+                continue;
+            }
+
+            if ($latest !== null) {
+                return $latest;
+            }
+
+            return $link;
+        }
+
+        return $latest;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function generatePackagesWhichWillBeReplaced(array $results)
+    {
+        $packages = [];
+
+        /**
+         * @var PackageInterface $package
+         * @var Link $link
+         * @var array $children
+         */
+        foreach ($results as list($package, $link, $children)) {
+            $packages[] = $this->generatePackagesWhichWillBeReplaced($children);
+            $packageName = $package->getName();
+            if (! $this->isZendPackage($packageName)) {
+                continue;
+            }
+
+            $replacement = $this->transformPackageName($packageName);
+            if ($packageName === $replacement) {
+                continue;
+            }
+
+            $packages[] = [$replacement];
+        }
+
+        /** @link https://github.com/kalessil/phpinspectionsea/blob/dbdf0e2fea67c8ec102dcef7e49c72f458385030/docs/performance.md#slow-array-function-used-in-loop */
+        $packages = array_merge([], ...$packages);
+
+        return array_unique($packages);
+    }
+
+    /**
+     * @return RepositoryInterface
+     */
+    private function createInstalledPackagesRepository(Composer $composer)
+    {
+        if ($this->installedRepo instanceof RepositoryInterface) {
+            return $this->installedRepo;
+        }
+
+        $rootPackage = $composer->getPackage();
+        $config = $rootPackage->getConfig();
+        $platformOverrides = [];
+        if (isset($config['platform'])) {
+            $platformOverrides = $config['platform'];
+        }
+
+        if (! class_exists(InstalledRepository::class)) {
+            $this->installedRepo = new CompositeRepository([
+                new ArrayRepository([$composer->getPackage()]),
+                $composer->getRepositoryManager()->getLocalRepository(),
+                new PlatformRepository([], $platformOverrides),
+            ]);
+
+            return $this->installedRepo;
+        }
+
+        $this->installedRepo = new InstalledRepository([
+            new RootPackageRepository($rootPackage),
+            $composer->getRepositoryManager()->getLocalRepository(),
+            new PlatformRepository([], $platformOverrides),
+        ]);
+
+        return $this->installedRepo;
+    }
+
+    /**
+     * @return ComposerFile
+     */
+    private function createComposerFile()
+    {
+        if ($this->composerFile) {
+            return $this->composerFile;
+        }
+        $this->composerFile = new ComposerFile(new JsonFile(Factory::getComposerFile()));
+        return $this->composerFile;
+    }
+
+    /**
+     * @param ComposerFile $composerFile
+     *
+     * @return ComposerFile
+     */
+    private function handlePackageInstallationsAndUpdates(ComposerFile $composerFile, array $packageReplacements)
+    {
+        $numberOfPackageReplacements = count($packageReplacements);
+        if ($numberOfPackageReplacements === 0) {
+            return $composerFile;
+        }
+
+        $this->output(sprintf(
+            '<info>Found %d zend packages which can be replaced with laminas packages.</info>',
+            $numberOfPackageReplacements
+        ));
+
+        if (! $this->confirm('Do you want to proceed? (Y/n) ')) {
+            return $composerFile;
+        }
+
+        $this->output('<info>Replacing zend packages with laminas packages in `composer.json`...</info>');
+        $composerFile = $this->replacePackagesInDefinition(
+            $composerFile,
+            $packageReplacements,
+            true
+        );
+        $composerFile->store();
+
+        $this->output('<info>Updating `composer.lock` to remove zend packages and install laminas pendants...</info>');
+        $exitCode = $this->updateLockFile(
+            array_merge(
+                array_keys($packageReplacements),
+                array_map(
+                    static function (array $data) {
+                        return $data[0];
+                    },
+                    array_values($packageReplacements)
+                )
+            )
+        );
+        if ($exitCode > 0) {
+            throw MigrationFailedException::lockFileUpdateFailed();
+        }
+
+        $this->output(
+            '<info>Update `composer.json` to to restore zend package constraints from 3rd-party package...</info>'
+        );
+        $composerFile = $this->replacePackagesInDefinition(
+            $composerFile,
+            $packageReplacements,
+            false
+        );
+
+        $composerFile->store();
+
+        $this->output('<info>Update `composer.lock` to synchronize with `composer.json`...</info>');
+        $exitCode = $this->updateLockFile([]);
+
+        if ($exitCode > 0) {
+            $this->output('<error>Migration failed. Could not update `composer.lock`!</error>');
+            throw MigrationFailedException::lockFileUpdateFailed();
+        }
+
+        return $composerFile;
+    }
+
+    /**
+     * @param ComposerFile $composerFile
+     * @param array        $nonMigratedPackageRemovals
+     * @param array        $laminasPackageRemovals
+     *
+     * @return ComposerFile
+     */
+    private function handlePackageUninstallations(
+        ComposerFile $composerFile,
+        array $nonMigratedPackageRemovals,
+        array $laminasPackageRemovals
+    ) {
+        $packagesToRemove = array_flip($laminasPackageRemovals);
+        foreach ($nonMigratedPackageRemovals as $package => $zendPackages) {
+            $composerFile = $composerFile->forgetNonMigratedPackage($package);
+            foreach ($zendPackages as $zendPackage) {
+                $laminasPackage = $this->transformPackageName($zendPackage);
+                if (in_array( $laminasPackage, $packagesToRemove, true)) {
+                    continue;
+                }
+
+                if (!$this->confirmThatPackageMayBeRemoved($laminasPackage, $package)) {
+                    continue;
+                }
+
+                $packagesToRemove[$zendPackage] = $laminasPackage;
+            }
+        }
+
+        if (!$packagesToRemove) {
+            $composerFile->store();
+
+            return $composerFile;
+        }
+
+        $laminasPackagesToRemove = array_values($packagesToRemove);
+
+        $this->output(
+            sprintf(
+                'Removing the following packages from composer.json: %s',
+                implode(', ', $laminasPackagesToRemove)
+            ),
+            IOInterface::DEBUG
+        );
+
+        $exitCode = $this->removePackages($laminasPackagesToRemove);
+        if ($exitCode > 0) {
+            throw MigrationFailedException::packageRemovalFailed($laminasPackagesToRemove);
+        }
+
+        $composerFile = $composerFile
+            ->withoutPackageRequirements($packagesToRemove);
+
+        $composerFile->store();
+        $this->output('<info>Updating `composer.lock` to synchronize with `composer.json`...</info>');
+        $this->updateLockFile([]);
+
+        return $composerFile;
+    }
+
+    /**
+     * Uses composer to remove dependencies AND updating the lock-file in the same run.
+     * @return int
+     */
+    private function removePackages(array $packagesToRemove)
+    {
+        $applicationFactory = $this->applicationFactory;
+        $application = $applicationFactory();
+        $output = ! $this->io->isVerbose() ? new NullOutput() : null;
+        $application->setAutoExit(false);
+
+        $input = [
+            'command' => 'remove',
+            '--no-plugins' => true,
+            '--no-scripts' => true,
+            '--working-dir' => getcwd(),
+            'packages' => $packagesToRemove,
+        ];
+
+        return $application->run(new ArrayInput($input), $output);
+    }
+
+    private function extractZendEquivalent(PackageInterface $package)
+    {
+        foreach ($package->getReplaces() as $replacement) {
+            if ($this->isZendPackage($replacement->getTarget())) {
+                return $replacement->getTarget();
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * @param ComposerFile $composerFile
+     * @param array        $nonMigratedPackageUpdates
+     *
+     * @return ComposerFile
+     */
+    private function handlePackageUpdates(ComposerFile $composerFile, array $nonMigratedPackageUpdates)
+    {
+        if (!$nonMigratedPackageUpdates) {
+            return $composerFile;
+        }
+
+        foreach ($nonMigratedPackageUpdates as $packageName => $package) {
+            $zendDependencies = $composerFile->getZendPackagesWhichWereReplacedByLaminasPackages($package);
+            $composerFile = $composerFile->updateNonMigratedPackages($package);
+            $zendDependenciesLeft = $this->extractZendDependencies($package);
+            $zendPackagesToRemove = array_filter(
+                $zendDependencies,
+                static function ($packageName) use ($zendDependenciesLeft) {
+                    return ! in_array($packageName, $zendDependenciesLeft, true);
+                }
+            );
+
+            foreach ($zendPackagesToRemove as $zendPackage) {
+                $laminasReplacement = $this->transformPackageName($zendPackage);
+                $nextConstraint = $composerFile->getNextConstraintFromNonMigratedPackages($zendPackage);
+                // There is no other (non-migrated) package which had a dependency on the zend package
+                if ($nextConstraint === '') {
+                    if ($this->confirmThatPackageMayBeRemoved($laminasReplacement, $packageName)) {
+                        $this->laminasPackageRemovals[$laminasReplacement] = $zendPackage;
+                    }
+                    continue;
+                }
+
+                list($packageName, $versionConstraint) = explode(':', $nextConstraint, 2);
+
+                $composerFile = $composerFile->withZendPackageReplacement(
+                    $zendPackage,
+                    $laminasReplacement,
+                    $packageName,
+                    $versionConstraint
+                );
+            }
+        }
+
+        $composerFile->store();
+
+        return $composerFile;
+    }
+
+    private function extractZendDependencies(PackageInterface $package)
+    {
+        $packages = [];
+        foreach ($package->getRequires() as $link) {
+            if (!$this->isZendPackage($link->getTarget())) {
+                continue;
+            }
+
+            $packages[] = $link->getTarget();
+        }
+
+        return $packages;
+    }
+
+    private function confirmThatPackageMayBeRemoved($laminasPackage, $dependant)
+    {
+        $this->output(
+            sprintf(
+                '<info>Laminas migration added package %s which can (probably) be removed'
+                . ' due to uninstallation or update of the package %s.</info>',
+                $laminasPackage,
+                $dependant
+            )
+        );
+        $this->output(
+            '<error>WARNING! Please verify, that you are not using the laminas dependency'
+            . ' in your project directly. If the package is removed, your code may break.</error>'
+        );
+
+        return $this->confirm(
+            sprintf(
+                'Do you want to remove %s from your dependencies? You will not be prompted again! (Y/n)', $laminasPackage
+            )
+        );
     }
 }

--- a/src/MigrationFailedException.php
+++ b/src/MigrationFailedException.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-dependency-plugin for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-dependency-plugin/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-dependency-plugin/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Laminas\DependencyPlugin;
+
+use RuntimeException;
+use function implode;
+
+final class MigrationFailedException extends RuntimeException
+{
+
+    public static function lockFileUpdateFailed()
+    {
+        return new self('Migration failed. Could not update `composer.lock`!');
+    }
+
+    public static function packageRemovalFailed(array $packages)
+    {
+        return new self(
+            sprintf(
+                'Migration failed. Could not remove the following packages: %s',
+                implode(', ', $packages)
+            )
+        );
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| BC Break      | yes
| New Feature   | yes

### Description

With this PR, I am introducing support for composer 2.0 aswell as a new behavior of this plugin (to stay in sync with composer 1.0.

I've added an ADR to the branch to provide some background on the decision to change the behavior of the plugin to a (hopefully) more future-proof way.

You can read this ADR in the next comment aswell as in the PR.


### TODO
- [x] Check if Travis build handles integration tests
- [ ] Add integration test for multiple non-migrated packages
- [ ] Add integration test for multiple non-migrated packages with shared dependencies
- [x] Add integration test with an update to a migrated package from a non-migrated package
- [x] Add uninstall handling of a package which was previously somehow required but not migrated
- [ ] Add integration test for uninstallation of a package which previously was not migrated
- [x] Add update handling of a package which was previously not migrated but is migrated with the newest version
- [x] Ask the user if we can remove the project requirement which was initially added by this plugin (in case it is not needed anymore)
- [ ] ...