### PR TITLE
Slip stream in composer 2.0

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,2 +1,0 @@
-coverage_clover: clover.xml
-json_path: coveralls-upload.json

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,3 @@
-/.coveralls.yml export-ignore
 /.gitattributes export-ignore
 /.github/ export-ignore
 /.gitignore export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,8 @@ matrix:
       env:
         - TEST_COVERAGE=true
         - COMPAT=true
+  allow_failures:
+    - php: nightly
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ env:
     - CS_CHECK=false
     - COMPOSER_ARGS="--no-interaction"
     - TEST_DEPS="phpunit/phpunit:^9.1 phpspec/prophecy-phpunit webimpress/coding-standard:^1.0"
-    - COVERAGE_DEPS="$TEST_DEPS php-coveralls/php-coveralls"
 
 matrix:
   include:
@@ -42,6 +41,7 @@ matrix:
     - php: 7.4
       env:
         - COMPOSER_VERSION=2
+        - TEST_COVERAGE=true
     - php: 7.4
       env:
         - TEST_COVERAGE=true
@@ -54,7 +54,7 @@ install:
   - travis_retry composer install $COMPOSER_ARGS
   - if [[ $COMPOSER_VERSION == "1" ]]; then travis_retry composer update composer/* --prefer-lowest ; fi
   - if [[ $TEST == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $TEST_DEPS ; fi
-  - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $COVERAGE_DEPS ; fi
+  - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $TEST_DEPS ; fi
   - stty cols 120 && composer show
 
 script:
@@ -62,8 +62,8 @@ script:
   - if [[ "$COMPAT" == 'true' ]]; then composer compat ; fi
   - if [[ $CS_CHECK == 'true' ]]; then composer cs-check ; fi
 
-after_script:
-  - if [[ $TEST_COVERAGE == 'true' ]]; then vendor/bin/php-coveralls -v ; fi
+after_success:
+  - bash <(curl -s https://codecov.io/bash)
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ script:
   - if [[ $CS_CHECK == 'true' ]]; then composer cs-check ; fi
 
 after_success:
-  - bash <(curl -s https://codecov.io/bash)
+  - bash <(curl -s https://codecov.io/bash) -cF composer${COMPOSER_VERSION}
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,10 +49,10 @@ matrix:
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
-  - travis_retry composer self-update --${COMPOSER_VERSION}
 
 install:
   - travis_retry composer install $COMPOSER_ARGS
+  - if [[ $COMPOSER_VERSION == "1" ]]; then travis_retry composer update composer/* --prefer-lowest ; fi
   - if [[ $TEST == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $TEST_DEPS ; fi
   - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $COVERAGE_DEPS ; fi
   - stty cols 120 && composer show

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ install:
   - stty cols 120 && composer show
 
 script:
-  - if [[ $TEST_COVERAGE == 'true' ]]; then composer test-coverage ; else if [[ $NO_TEST != '1' ]]; then  composer test ; fi ; fi
+  - if [[ $TEST_COVERAGE == 'true' ]]; then composer test-coverage ; else if [[ $TEST != 'false' ]]; then  composer test ; fi ; fi
   - if [[ "$COMPAT" == 'true' ]]; then composer compat ; fi
   - if [[ $CS_CHECK == 'true' ]]; then composer cs-check ; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ env:
     - TEST=false
     - CS_CHECK=false
     - COMPOSER_ARGS="--no-interaction"
-    - COVERAGE_DEPS="php-coveralls/php-coveralls"
     - TEST_DEPS="phpunit/phpunit:^9.1 phpspec/prophecy-phpunit webimpress/coding-standard:^1.0"
+    - COVERAGE_DEPS="$TEST_DEPS php-coveralls/php-coveralls"
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,49 +6,61 @@ cache:
 
 env:
   global:
+    - COMPOSER_VERSION="1"
+    - COMPAT=false
+    - TEST=false
+    - CS_CHECK=false
     - COMPOSER_ARGS="--no-interaction"
     - COVERAGE_DEPS="php-coveralls/php-coveralls"
-    - NO_TEST_DEPS="phpunit/phpunit webimpress/coding-standard"
+    - TEST_DEPS="phpunit/phpunit:^8.5 webimpress/coding-standard:^1.0"
 
 matrix:
   include:
     - php: 5.6
+    - php: 5.6
       env:
-        - COMPAT_VERSION=5.6
-        - NO_TEST=1
+        - COMPOSER_VERSION=2
+    - php: 7.0
     - php: 7.0
       env:
-        - COMPAT_VERSION=7.0
-        - NO_TEST=1
+        - COMPOSER_VERSION=2
+    - php: 7.1
     - php: 7.1
       env:
-        - COMPAT_VERSION=7.1
-        - NO_TEST=1
+        - COMPOSER_VERSION=2
+    - php: 7.2
     - php: 7.2
       env:
-        - TEST_COVERAGE=true
-        - COMPAT_VERSION=7.2
+        - COMPOSER_VERSION=2
     - php: 7.3
       env:
-        - COMPAT_VERSION=7.3
-        - CS_CHECK=1
+        - COMPOSER_VERSION=2
+    - php: 7.3
+      env:
+        - TEST=true
+        - CS_CHECK=true
     - php: 7.4
       env:
-        - COMPAT_VERSION=7.4
+        - COMPOSER_VERSION=2
+    - php: 7.4
+      env:
+        - TEST_COVERAGE=true
+        - COMPAT=true
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
+  - travis_retry composer self-update --${COMPOSER_VERSION}
 
 install:
-  - if [[ $NO_TEST == '1' ]]; then travis_retry composer remove --dev $COMPOSER_ARGS $NO_TEST_DEPS ; fi
   - travis_retry composer install $COMPOSER_ARGS
+  - if [[ $TEST == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $TEST_DEPS ; fi
   - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $COVERAGE_DEPS ; fi
   - stty cols 120 && composer show
 
 script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then composer test-coverage ; else if [[ $NO_TEST != '1' ]]; then  composer test ; fi ; fi
-  - if [[ $COMPAT_VERSION != '0' ]]; then composer cs-check -- -p src --standard=PHPCompatibility --runtime-set testVersion $COMPAT_VERSION ; fi
-  - if [[ $CS_CHECK == '1' ]]; then composer cs-check ; fi
+  - if [[ "$COMPAT" == 'true' ]]; then composer compat ; fi
+  - if [[ $CS_CHECK == 'true' ]]; then composer cs-check ; fi
 
 after_script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then vendor/bin/php-coveralls -v ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
     - CS_CHECK=false
     - COMPOSER_ARGS="--no-interaction"
     - COVERAGE_DEPS="php-coveralls/php-coveralls"
-    - TEST_DEPS="phpunit/phpunit:^8.5 webimpress/coding-standard:^1.0"
+    - TEST_DEPS="phpunit/phpunit:^9.1 phpspec/prophecy-phpunit webimpress/coding-standard:^1.0"
 
 matrix:
   include:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build Status](https://travis-ci.com/laminas/laminas-dependency-plugin.svg?branch=master)](https://travis-ci.com/laminas/laminas-dependency-plugin)
 
+[![codecov](https://codecov.io/gh/laminas/laminas-dependency-plugin/branch/master/graph/badge.svg)](https://codecov.io/gh/laminas/laminas-dependency-plugin)
+
 This Composer plugin, when enabled in a project, intercepts requests to install
 packages from the zendframework and zfcampus vendors, and will replace them with
 the equivalents from the Laminas Project.

--- a/autoload/composer-2.0.php
+++ b/autoload/composer-2.0.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Composer\Plugin;
+
+if (!class_exists(PrePoolCreateEvent::class)) {
+    class PrePoolCreateEvent {}
+}

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "composer-plugin-api": "^1.1 || ^2.0"
     },
     "require-dev": {
-        "composer/composer": "^1.9 || ^2.0@dev",
+        "composer/composer": "^1.9 || ~2.0.0@dev || ^2.0",
         "mikey179/vfsstream": "^1.6",
         "phpcompatibility/php-compatibility": "^9.3",
         "roave/security-advisories": "dev-master"

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
     },
     "require-dev": {
         "composer/composer": "^1.9 || ^2.0@dev",
-        "composer/semver": "^1.5 || ^2.1@dev",
         "mikey179/vfsstream": "^1.6",
         "phpcompatibility/php-compatibility": "^9.3",
         "roave/security-advisories": "dev-master"

--- a/composer.json
+++ b/composer.json
@@ -8,15 +8,14 @@
     },
     "require": {
         "php": "^5.6 || ^7.0",
-        "composer-plugin-api": "^1.1"
+        "composer-plugin-api": "^1.1 || ^2.0"
     },
     "require-dev": {
-        "composer/composer": "^1.9",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
+        "composer/composer": "^1.9 || ^2.0@dev",
+        "composer/semver": "^1.5 || ^2.1@dev",
+        "mikey179/vfsstream": "^1.6",
         "phpcompatibility/php-compatibility": "^9.3",
-        "phpunit/phpunit": "^8.4",
-        "roave/security-advisories": "dev-master",
-        "webimpress/coding-standard": "^1.0"
+        "roave/security-advisories": "dev-master"
     },
     "autoload": {
         "psr-4": {
@@ -26,23 +25,28 @@
     "autoload-dev": {
         "psr-4": {
             "LaminasTest\\DependencyPlugin\\": "test/"
-        }
+        },
+        "files": ["autoload/composer-2.0.php"]
     },
     "extra": {
         "branch-alias": {
             "dev-master": "1.0.x-dev",
             "dev-develop": "1.1.x-dev"
         },
-        "class": "Laminas\\DependencyPlugin\\DependencyRewriterPlugin"
+        "class": "Laminas\\DependencyPlugin\\DependencyRewriterPluginDelegator"
     },
     "scripts": {
         "check": [
             "@cs-check",
+            "@compat",
             "@test"
         ],
         "cs-check": "phpcs",
         "cs-fix": "phpcbf",
         "test": "phpunit --colors=always",
-        "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
+        "test-coverage": "phpunit --colors=always --coverage-clover clover.xml",
+        "post-install-cmd": "phpcs --config-set installed_paths vendor/phpcompatibility/php-compatibility",
+        "post-update-cmd" : "phpcs --config-set installed_paths vendor/phpcompatibility/php-compatibility",
+        "compat": "phpcs --standard=PHPCompatibility src/ -- --runtime-set testVersion 5.6-"
     }
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,14 +1,18 @@
 <?xml version="1.0"?>
 <ruleset name="Webimpress Coding Standard">
-    <rule ref="./vendor/webimpress/coding-standard/ruleset.xml"/>
+    <rule ref="./vendor/webimpress/coding-standard/ruleset.xml">
+        <exclude name="WebimpressCodingStandard.Functions.NullableTypehint"/>
+    </rule>
 
     <!-- Paths to check -->
     <file>src</file>
     <file>test</file>
 
-    <exclude-pattern>test/*/TestAsset/</exclude-pattern>
-
     <rule ref="WebimpressCodingStandard.PHP.DeclareStrictTypes">
-        <exclude-pattern>src/DependencyRewriterPlugin.php</exclude-pattern>
+        <exclude-pattern>src/*</exclude-pattern>
+    </rule>
+
+    <rule ref="Generic.NamingConventions.CamelCapsFunctionName">
+        <exclude-pattern>test/*</exclude-pattern>
     </rule>
 </ruleset>

--- a/src/AbstractDependencyRewriter.php
+++ b/src/AbstractDependencyRewriter.php
@@ -1,0 +1,156 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-dependency-plugin for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-dependency-plugin/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-dependency-plugin/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Laminas\DependencyPlugin;
+
+use Composer\Composer;
+use Composer\Installer\PackageEvent;
+use Composer\IO\IOInterface;
+use Composer\Plugin\PreCommandRunEvent;
+
+use function array_map;
+use function array_shift;
+use function count;
+use function get_class;
+use function in_array;
+use function preg_split;
+use function sprintf;
+
+abstract class AbstractDependencyRewriter implements RewriterInterface
+{
+    /** @var Composer */
+    protected $composer;
+
+    /** @var IOInterface */
+    protected $io;
+
+    /**
+     * @var Replacements
+     */
+    private $replacements;
+
+    public function __construct()
+    {
+        $this->replacements = new Replacements();
+    }
+
+    public function activate(Composer $composer, IOInterface $io)
+    {
+        $this->composer = $composer;
+        $this->io = $io;
+        $this->output(sprintf('<info>Activating %s</info>', get_class($this)), IOInterface::DEBUG);
+    }
+
+    /**
+     * When a ZF package is requested, replace with the Laminas variant.
+     *
+     * When a `require` operation is requested, and a ZF package is detected,
+     * this listener will replace the argument with the equivalent Laminas
+     * package. This ensures that the `composer.json` file is written to
+     * reflect the package installed.
+     */
+    public function onPreCommandRun(PreCommandRunEvent $event)
+    {
+        $this->output(
+            sprintf(
+                '<info>In %s::%s</info>',
+                get_class($this),
+                __FUNCTION__
+            ),
+            IOInterface::DEBUG
+        );
+
+        if (! in_array($event->getCommand(), ['require', 'update'], true)) {
+            // Nothing to do here.
+            return;
+        }
+
+        $input = $event->getInput();
+        if (! $input->hasArgument('packages')) {
+            return;
+        }
+
+        $input->setArgument(
+            'packages',
+            array_map([$this, 'updatePackageArgument'], $input->getArgument('packages'))
+        );
+    }
+
+    abstract public function onPrePackageInstallOrUpdate(PackageEvent $event);
+
+    /**
+     * @param string $message
+     * @param int $verbosity
+     */
+    protected function output($message, $verbosity = IOInterface::NORMAL)
+    {
+        $this->io->write($message, $newline = true, $verbosity);
+    }
+
+    /**
+     * Parses a package argument from the command line, replacing it with the
+     * Laminas variant if it exists.
+     *
+     * @param string $package Package specification from command line
+     * @return string Modified package specification containing Laminas
+     *     substitution, or original if no changes required.
+     */
+    private function updatePackageArgument($package)
+    {
+        $result = preg_split('/[ :=]/', $package, 2);
+        if ($result === false) {
+            return $package;
+        }
+        $name = array_shift($result);
+
+        if (! $this->isZendPackage($name)) {
+            return $package;
+        }
+
+        $replacementName = $this->transformPackageName($name);
+        if ($replacementName === $name) {
+            return $package;
+        }
+
+        $this->io->write(
+            sprintf(
+                'Changing package in current command from %s to %s',
+                $name,
+                $replacementName
+            ),
+            true,
+            IOInterface::DEBUG
+        );
+
+        $version = count($result) ? array_shift($result) : null;
+
+        if ($version === null) {
+            return $replacementName;
+        }
+
+        return sprintf('%s:%s', $replacementName, $version);
+    }
+
+    /**
+     * @param string $name
+     * @return bool
+     */
+    protected function isZendPackage($name)
+    {
+        return $this->replacements->isZendPackage($name);
+    }
+
+    /**
+     * @param string $name
+     * @return string
+     */
+    protected function transformPackageName($name)
+    {
+        return $this->replacements->transformPackageName($name);
+    }
+}

--- a/src/AbstractDependencyRewriter.php
+++ b/src/AbstractDependencyRewriter.php
@@ -15,10 +15,10 @@ use Composer\Plugin\PreCommandRunEvent;
 
 use function array_map;
 use function array_shift;
-use function count;
 use function get_class;
 use function in_array;
 use function preg_split;
+use function reset;
 use function sprintf;
 
 abstract class AbstractDependencyRewriter implements RewriterInterface
@@ -127,9 +127,9 @@ abstract class AbstractDependencyRewriter implements RewriterInterface
             IOInterface::DEBUG
         );
 
-        $version = count($result) ? array_shift($result) : null;
+        $version = reset($result);
 
-        if ($version === null) {
+        if ($version === false) {
             return $replacementName;
         }
 

--- a/src/AbstractDependencyRewriter.php
+++ b/src/AbstractDependencyRewriter.php
@@ -89,7 +89,7 @@ abstract class AbstractDependencyRewriter implements RewriterInterface
      */
     protected function output($message, $verbosity = IOInterface::NORMAL)
     {
-        $this->io->write($message, $newline = true, $verbosity);
+        $this->io->write($message, true, $verbosity);
     }
 
     /**

--- a/src/AutoloadDumpCapableInterface.php
+++ b/src/AutoloadDumpCapableInterface.php
@@ -8,7 +8,9 @@
 
 namespace Laminas\DependencyPlugin;
 
-/** @deprecated */
-class DependencyRewriterPlugin extends DependencyRewriterPluginDelegator
+use Composer\Script\Event;
+
+interface AutoloadDumpCapableInterface extends RewriterInterface
 {
+    public function onPostAutoloadDump(Event $event);
 }

--- a/src/DependencyRewriterPluginDelegator.php
+++ b/src/DependencyRewriterPluginDelegator.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-dependency-plugin for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-dependency-plugin/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-dependency-plugin/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Laminas\DependencyPlugin;
+
+use Composer\Composer;
+use Composer\EventDispatcher\EventSubscriberInterface;
+use Composer\Installer\InstallerEvent;
+use Composer\Installer\InstallerEvents;
+use Composer\Installer\PackageEvent;
+use Composer\Installer\PackageEvents;
+use Composer\IO\IOInterface;
+use Composer\Plugin\PluginEvents;
+use Composer\Plugin\PluginInterface;
+use Composer\Plugin\PreCommandRunEvent;
+use Composer\Plugin\PrePoolCreateEvent;
+use Composer\Script\Event;
+use Composer\Script\ScriptEvents;
+
+use function assert;
+use function version_compare;
+
+class DependencyRewriterPluginDelegator implements EventSubscriberInterface, PluginInterface
+{
+    /**
+     * @var RewriterInterface
+     */
+    private $rewriter;
+
+    public function __construct(RewriterInterface $rewriter = null)
+    {
+        $this->rewriter = $rewriter
+            ?: $this->createDependencyRewriterForPluginVersion(PluginInterface::PLUGIN_API_VERSION);
+    }
+
+    /**
+     * @return array Returns in following format:
+     *     <string> => array<string, int>
+     */
+    public static function getSubscribedEvents()
+    {
+        if (version_compare(PluginInterface::PLUGIN_API_VERSION, '2.0', 'lt')) {
+            return [
+                InstallerEvents::PRE_DEPENDENCIES_SOLVING => ['onPreDependenciesSolving', 1000],
+                PackageEvents::PRE_PACKAGE_INSTALL => ['onPrePackageInstallOrUpdate', 1000],
+                PackageEvents::PRE_PACKAGE_UPDATE => ['onPrePackageInstallOrUpdate', 1000],
+                PluginEvents::PRE_COMMAND_RUN => ['onPreCommandRun', 1000],
+            ];
+        }
+
+        return [
+            PluginEvents::PRE_POOL_CREATE => ['onPrePoolCreate', 1000],
+            PackageEvents::PRE_PACKAGE_INSTALL => ['onPrePackageInstallOrUpdate', 1000],
+            PackageEvents::PRE_PACKAGE_UPDATE => ['onPrePackageInstallOrUpdate', 1000],
+            PluginEvents::PRE_COMMAND_RUN => ['onPreCommandRun', 1000],
+            ScriptEvents::POST_AUTOLOAD_DUMP => ['onPostAutoloadDump', -1000],
+        ];
+    }
+
+    public function onPreDependenciesSolving(InstallerEvent $event)
+    {
+        $rewriter = $this->rewriter;
+        assert($rewriter instanceof DependencySolvingCapableInterface);
+        $rewriter->onPreDependenciesSolving($event);
+    }
+
+    public function onPrePackageInstallOrUpdate(PackageEvent $event)
+    {
+        $this->rewriter->onPrePackageInstallOrUpdate($event);
+    }
+
+    public function onPreCommandRun(PreCommandRunEvent $event)
+    {
+        $this->rewriter->onPreCommandRun($event);
+    }
+
+    public function onPrePoolCreate(PrePoolCreateEvent $event)
+    {
+        $rewriter = $this->rewriter;
+        assert($rewriter instanceof PoolCapableInterface);
+        $rewriter->onPrePoolCreate($event);
+    }
+
+    public function onPostAutoloadDump(Event $event)
+    {
+        $rewriter = $this->rewriter;
+        assert($rewriter instanceof AutoloadDumpCapableInterface);
+        $rewriter->onPostAutoloadDump($event);
+    }
+
+    public function activate(Composer $composer, IOInterface $io)
+    {
+        $this->rewriter->activate($composer, $io);
+    }
+
+    public function deactivate(Composer $composer, IOInterface $io)
+    {
+    }
+
+    public function uninstall(Composer $composer, IOInterface $io)
+    {
+    }
+
+    /**
+     * @param string $pluginApiVersion
+     * @return DependencyRewriterV1|DependencyRewriterV2
+     */
+    private function createDependencyRewriterForPluginVersion($pluginApiVersion)
+    {
+        if (version_compare($pluginApiVersion, '2.0', 'lt')) {
+            return new DependencyRewriterV1();
+        }
+
+        return new DependencyRewriterV2();
+    }
+}

--- a/src/DependencyRewriterV1.php
+++ b/src/DependencyRewriterV1.php
@@ -160,6 +160,7 @@ final class DependencyRewriterV1 extends AbstractDependencyRewriter
      */
     private function updateProperty($object, $property, $value)
     {
+        // @phpcs:ignore WebimpressCodingStandard.PHP.StaticCallback.Static
         (function ($object, $property, $value) {
             $object->$property = $value;
         })->bindTo($object, $object)($object, $property, $value);

--- a/src/DependencyRewriterV1.php
+++ b/src/DependencyRewriterV1.php
@@ -13,7 +13,6 @@ use Composer\Installer\InstallerEvent;
 use Composer\Installer\PackageEvent;
 use Composer\IO\IOInterface;
 use Composer\Package\PackageInterface;
-use ReflectionProperty;
 
 use function get_class;
 use function in_array;
@@ -161,8 +160,8 @@ final class DependencyRewriterV1 extends AbstractDependencyRewriter
      */
     private function updateProperty($object, $property, $value)
     {
-        $r = new ReflectionProperty($object, $property);
-        $r->setAccessible(true);
-        $r->setValue($object, $value);
+        (static function ($object, $property, $value) {
+            $object->$property = $value;
+        })->bindTo($object, $object)($object, $property, $value);
     }
 }

--- a/src/DependencyRewriterV1.php
+++ b/src/DependencyRewriterV1.php
@@ -160,7 +160,7 @@ final class DependencyRewriterV1 extends AbstractDependencyRewriter
      */
     private function updateProperty($object, $property, $value)
     {
-        (static function ($object, $property, $value) {
+        (function ($object, $property, $value) {
             $object->$property = $value;
         })->bindTo($object, $object)($object, $property, $value);
     }

--- a/src/DependencyRewriterV1.php
+++ b/src/DependencyRewriterV1.php
@@ -1,0 +1,168 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-dependency-plugin for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-dependency-plugin/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-dependency-plugin/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Laminas\DependencyPlugin;
+
+use Composer\DependencyResolver\Operation;
+use Composer\Installer\InstallerEvent;
+use Composer\Installer\PackageEvent;
+use Composer\IO\IOInterface;
+use Composer\Package\PackageInterface;
+use ReflectionProperty;
+
+use function get_class;
+use function in_array;
+use function sprintf;
+
+final class DependencyRewriterV1 extends AbstractDependencyRewriter
+{
+    /**
+     * Replace ZF packages present in the composer.json during install or
+     * update operations.
+     *
+     * When the `composer.json` has references to ZF packages, and the user
+     * requests an `install` or `update`, this method will rewrite any such
+     * packages to their Laminas equivalents prior to attempting to resolve
+     * dependencies, ensuring the Laminas versions are installed.
+     */
+    public function onPreDependenciesSolving(InstallerEvent $event)
+    {
+        $this->output(sprintf('<info>In %s</info>', __METHOD__), IOInterface::DEBUG);
+        $request = $event->getRequest();
+        $jobs = $request->getJobs();
+        $changes = false;
+
+        foreach ($jobs as $index => $job) {
+            if (! isset($job['cmd']) || ! in_array($job['cmd'], ['install', 'update'], true)) {
+                continue;
+            }
+
+            if (! isset($job['packageName'])) {
+                continue;
+            }
+
+            $name = $job['packageName'];
+            if (! $this->isZendPackage($name)) {
+                continue;
+            }
+
+            $replacementName = $this->transformPackageName($name);
+            if ($replacementName === $name) {
+                continue;
+            }
+
+            $this->output(sprintf(
+                '<info>Replacing package "%s" with package "%s"</info>',
+                $name,
+                $replacementName
+            ), IOInterface::VERBOSE);
+
+            $job['packageName'] = $replacementName;
+            $jobs[$index] = $job;
+            $changes = true;
+        }
+
+        if (! $changes) {
+            return;
+        }
+
+        $this->updateProperty($request, 'jobs', $jobs);
+    }
+
+    /**
+     * Ensure nested dependencies on ZF packages install equivalent Laminas packages.
+     *
+     * When a 3rd party package has dependencies on ZF packages, this method
+     * will detect the request to install a ZF package, and rewrite it to use a
+     * Laminas variant at the equivalent version, if one exists.
+     */
+    public function onPrePackageInstallOrUpdate(PackageEvent $event)
+    {
+        $this->output(sprintf('<info>In %s</info>', __METHOD__), IOInterface::DEBUG);
+        $operation = $event->getOperation();
+
+        switch (true) {
+            case $operation instanceof Operation\InstallOperation:
+                $package = $operation->getPackage();
+                break;
+            case $operation instanceof Operation\UpdateOperation:
+                $package = $operation->getTargetPackage();
+                break;
+            default:
+                // Nothing to do
+                $this->output(sprintf(
+                    '<info>Exiting; operation of type %s not supported</info>',
+                    get_class($operation)
+                ), IOInterface::DEBUG);
+                return;
+        }
+
+        $name = $package->getName();
+        if (! $this->isZendPackage($name)) {
+            // Nothing to do
+            $this->output(sprintf(
+                '<info>Exiting; package "%s" does not have a replacement</info>',
+                $name
+            ), IOInterface::DEBUG);
+            return;
+        }
+
+        $replacementName = $this->transformPackageName($name);
+        if ($replacementName === $name) {
+            // Nothing to do
+            $this->output(sprintf(
+                '<info>Exiting; while package "%s" is a ZF package, it does not have a replacement</info>',
+                $name
+            ), IOInterface::DEBUG);
+            return;
+        }
+
+        $version = $package->getVersion();
+        $replacementPackage = $this->composer->getRepositoryManager()->findPackage($replacementName, $version);
+
+        if ($replacementPackage === null) {
+            // No matching replacement package found
+            $this->output(sprintf(
+                '<info>Exiting; no replacement package found for package "%s" with version %s</info>',
+                $replacementName,
+                $version
+            ), IOInterface::DEBUG);
+            return;
+        }
+
+        $this->output(sprintf(
+            '<info>Replacing package %s with package %s, using version %s</info>',
+            $name,
+            $replacementName,
+            $version
+        ), IOInterface::VERBOSE);
+
+        $this->replacePackageInOperation($replacementPackage, $operation);
+    }
+
+    private function replacePackageInOperation(PackageInterface $replacement, Operation\OperationInterface $operation)
+    {
+        $this->updateProperty(
+            $operation,
+            $operation instanceof Operation\UpdateOperation ? 'targetPackage' : 'package',
+            $replacement
+        );
+    }
+
+    /**
+     * @param object $object
+     * @param string $property
+     * @param mixed $value
+     */
+    private function updateProperty($object, $property, $value)
+    {
+        $r = new ReflectionProperty($object, $property);
+        $r->setAccessible(true);
+        $r->setValue($object, $value);
+    }
+}

--- a/src/DependencyRewriterV2.php
+++ b/src/DependencyRewriterV2.php
@@ -1,0 +1,323 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-dependency-plugin for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-dependency-plugin/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-dependency-plugin/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Laminas\DependencyPlugin;
+
+use Composer\Composer;
+use Composer\Console\Application;
+use Composer\DependencyResolver\Operation;
+use Composer\Factory;
+use Composer\Installer\PackageEvent;
+use Composer\IO\IOInterface;
+use Composer\Json\JsonFile;
+use Composer\Package\PackageInterface;
+use Composer\Plugin\PrePoolCreateEvent;
+use Composer\Repository\InstalledFilesystemRepository;
+use Composer\Script\Event;
+use Symfony\Component\Console\Input\ArrayInput;
+
+use function assert;
+use function call_user_func;
+use function dirname;
+use function get_class;
+use function in_array;
+use function is_array;
+use function ksort;
+use function sprintf;
+
+final class DependencyRewriterV2 extends AbstractDependencyRewriter implements
+    PoolCapableInterface,
+    AutoloadDumpCapableInterface
+{
+    /**
+     * @var PackageInterface[]
+     */
+    private $zendPackagesInstalled = [];
+
+    /**
+     * @var callable
+     */
+    private $applicationFactory;
+
+    /**
+     * @var string
+     */
+    private $composerFile;
+
+    /**
+     * @param string $composerFile
+     */
+    public function __construct(callable $applicationFactory = null, $composerFile = '')
+    {
+        parent::__construct();
+        $this->composerFile = $composerFile ?: Factory::getComposerFile();
+        $this->applicationFactory = $applicationFactory ?: static function () {
+            return new Application();
+        };
+    }
+
+    /**
+     * Ensure nested dependencies on ZF packages install equivalent Laminas packages.
+     *
+     * When a 3rd party package has dependencies on ZF packages, this method
+     * will detect the request to install a ZF package, and rewrite it to use a
+     * Laminas variant at the equivalent version, if one exists.
+     */
+    public function onPrePackageInstallOrUpdate(PackageEvent $event)
+    {
+        $this->output(sprintf('<info>In %s</info>', __METHOD__), IOInterface::DEBUG);
+        $operation = $event->getOperation();
+
+        switch (true) {
+            case $operation instanceof Operation\InstallOperation:
+                $package = $operation->getPackage();
+                break;
+            case $operation instanceof Operation\UpdateOperation:
+                $package = $operation->getTargetPackage();
+                break;
+            default:
+                // Nothing to do
+                $this->output(sprintf(
+                    '<info>Exiting; operation of type %s not supported</info>',
+                    get_class($operation)
+                ), IOInterface::DEBUG);
+                return;
+        }
+
+        $name = $package->getName();
+        if (! $this->isZendPackage($name)) {
+            // Nothing to do
+            $this->output(sprintf(
+                '<info>Exiting; package "%s" does not have a replacement</info>',
+                $name
+            ), IOInterface::DEBUG);
+            return;
+        }
+
+        $replacementName = $this->transformPackageName($name);
+        if ($replacementName === $name) {
+            // Nothing to do
+            $this->output(sprintf(
+                '<info>Exiting; while package "%s" is a ZF package, it does not have a replacement</info>',
+                $name
+            ), IOInterface::DEBUG);
+            return;
+        }
+
+        $version = $package->getVersion();
+        $replacementPackage = $this->composer->getRepositoryManager()->findPackage($replacementName, $version);
+
+        if ($replacementPackage === null) {
+            // No matching replacement package found
+            $this->output(sprintf(
+                '<info>Exiting; no replacement package found for package "%s" with version %s</info>',
+                $replacementName,
+                $version
+            ), IOInterface::DEBUG);
+            return;
+        }
+
+        $this->output(sprintf(
+            '<info>Could replace package %s with package %s, using version %s</info>',
+            $name,
+            $replacementName,
+            $version
+        ), IOInterface::VERBOSE);
+
+        $this->zendPackagesInstalled[] = $package;
+    }
+
+    public function onPostAutoloadDump(Event $event)
+    {
+        if (! $this->zendPackagesInstalled) {
+            return;
+        }
+
+        // Remove zend-packages from vendor/ directory
+        $composer = $event->getComposer();
+        $installers = $composer->getInstallationManager();
+        $repository = $composer->getRepositoryManager()->getLocalRepository();
+
+        $composerFile = $this->createComposerFile();
+        $definition = $composerFile->read();
+        assert(is_array($definition));
+        $definitionChanged = false;
+
+        foreach ($this->zendPackagesInstalled as $package) {
+            $packageName = $package->getName();
+            $replacementName = $this->transformPackageName($packageName);
+            if ($this->isRootRequirement($definition, $packageName)) {
+                $this->output(sprintf(
+                    '<info>Package %s is a root requirement. laminas-dependency-plugin changes your composer.json'
+                    . ' to require laminas equivalent directly!</info>',
+                    $packageName
+                ));
+
+                $definitionChanged = true;
+                $definition = $this->updateRootRequirements(
+                    $definition,
+                    $packageName,
+                    $replacementName
+                );
+            }
+
+            $uninstallOperation = new Operation\UninstallOperation($package);
+            $installers->uninstall($repository, $uninstallOperation);
+        }
+
+        if ($definitionChanged) {
+            $composerFile->write($definition);
+        }
+
+        $this->updateLockFile();
+    }
+
+    public function onPrePoolCreate(PrePoolCreateEvent $event)
+    {
+        $this->output(sprintf('In %s', __METHOD__));
+
+        $installedRepository = $this->createInstalledRepository($this->composer, $this->io);
+        $installedPackages = $installedRepository->getPackages();
+
+        $installedZendPackages = [];
+
+        foreach ($installedPackages as $package) {
+            if (! $this->isZendPackage($package->getName())) {
+                continue;
+            }
+
+            $installedZendPackages[] = $package->getName();
+        }
+
+        if (! $installedZendPackages) {
+            return;
+        }
+
+        $unacceptableFixedPackages = $event->getUnacceptableFixedPackages();
+        $repository = $this->composer->getRepositoryManager();
+        $packages = $event->getPackages();
+
+        foreach ($packages as $index => $package) {
+            if (! in_array($package->getName(), $installedZendPackages, true)) {
+                continue;
+            }
+
+            $replacement = $this->transformPackageName($package->getName());
+            if ($replacement === $package->getName()) {
+                continue;
+            }
+
+            $replacementPackage = $repository->findPackage($replacement, $package->getVersion());
+            if (! $replacementPackage instanceof PackageInterface) {
+                continue;
+            }
+
+            $unacceptableFixedPackages[] = $package;
+
+            $this->output(sprintf('Slipstreaming %s => %s', $package->getName(), $replacement));
+            $packages[$index] = $replacementPackage;
+        }
+
+        $event->setUnacceptableFixedPackages($unacceptableFixedPackages);
+        $event->setPackages($packages);
+    }
+
+    /**
+     * With `composer update --lock`, all missing packages are being installed aswell.
+     * This is where we slip-stream in with our plugin.
+     */
+    private function updateLockFile()
+    {
+        $application = call_user_func($this->applicationFactory);
+        assert($application instanceof Application);
+
+        $application->setAutoExit(false);
+
+        $input = [
+            'command' => 'update',
+            '--lock' => true,
+            '--no-scripts' => true,
+            '--working-dir' => dirname($this->composerFile),
+        ];
+
+        $application->run(new ArrayInput($input));
+    }
+
+    /**
+     * @return InstalledFilesystemRepository
+     */
+    private function createInstalledRepository(Composer $composer, IOInterface $io)
+    {
+        $vendor = $composer->getConfig()->get('vendor-dir');
+
+        return new InstalledFilesystemRepository(
+            new JsonFile($vendor . '/composer/installed.json', null, $io),
+            true,
+            $composer->getPackage()
+        );
+    }
+
+    /**
+     * @param string $packageName
+     * @return bool
+     */
+    private function isRootRequirement(array $definition, $packageName)
+    {
+        return isset($definition['require'][$packageName]) || isset($definition['require-dev'][$packageName]);
+    }
+
+    /**
+     * @param string $packageName
+     * @param string $replacementPackageName
+     * @return array
+     */
+    private function updateRootRequirements(array $definition, $packageName, $replacementPackageName)
+    {
+        $sortPackages = false;
+        if (isset($definition['config']['sort-packages'])) {
+            $sortPackages = $definition['config']['sort-packages'];
+        }
+
+        foreach (['require', 'require-dev'] as $key) {
+            if (! isset($definition[$key])) {
+                continue;
+            }
+
+            $requirements = $definition[$key];
+            if (! isset($requirements[$packageName])) {
+                continue;
+            }
+
+            $requirements[$replacementPackageName] = $requirements[$packageName];
+            unset($requirements[$packageName]);
+            if ($sortPackages) {
+                ksort($requirements);
+            }
+
+            $definition[$key] = $requirements;
+        }
+
+        return $definition;
+    }
+
+    /**
+     * @return PackageInterface[]
+     */
+    public function getZendPackagesInstalled()
+    {
+        return $this->zendPackagesInstalled;
+    }
+
+    /**
+     * @return JsonFile
+     */
+    private function createComposerFile()
+    {
+        return new JsonFile($this->composerFile, null, $this->io);
+    }
+}

--- a/src/DependencySolvingCapableInterface.php
+++ b/src/DependencySolvingCapableInterface.php
@@ -8,7 +8,12 @@
 
 namespace Laminas\DependencyPlugin;
 
-/** @deprecated */
-class DependencyRewriterPlugin extends DependencyRewriterPluginDelegator
+use Composer\Installer\InstallerEvent;
+
+interface DependencySolvingCapableInterface extends RewriterInterface
 {
+    /**
+     * If a ZF package is being installed, modify the incoming request to slip-stream laminas packages.
+     */
+    public function onPreDependenciesSolving(InstallerEvent $event);
 }

--- a/src/PoolCapableInterface.php
+++ b/src/PoolCapableInterface.php
@@ -8,7 +8,12 @@
 
 namespace Laminas\DependencyPlugin;
 
-/** @deprecated */
-class DependencyRewriterPlugin extends DependencyRewriterPluginDelegator
+use Composer\Plugin\PrePoolCreateEvent;
+
+interface PoolCapableInterface extends RewriterInterface
 {
+    /**
+     * If a ZF package is being installed, ensure the pool is modified to install the laminas equivalent instead.
+     */
+    public function onPrePoolCreate(PrePoolCreateEvent $event);
 }

--- a/src/Replacements.php
+++ b/src/Replacements.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-dependency-plugin for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-dependency-plugin/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-dependency-plugin/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Laminas\DependencyPlugin;
+
+use function in_array;
+use function preg_match;
+use function sprintf;
+
+final class Replacements
+{
+    /** @var string[] */
+    private $ignore = [
+        'zendframework/zend-debug',
+        'zendframework/zend-version',
+        'zendframework/zendservice-apple-apns',
+        'zendframework/zendservice-google-gcm',
+        'zfcampus/zf-apigility-example',
+        'zfcampus/zf-angular',
+        'zfcampus/zf-console',
+        'zfcampus/zf-deploy',
+    ];
+
+    /**
+     * @param string $name Original package name
+     * @return string Transformed (or original) package name
+     */
+    public function transformPackageName($name)
+    {
+        switch ($name) {
+            // Packages without replacements:
+            case in_array($name, $this->ignore, true):
+                return $name;
+            // Packages with non-standard naming:
+            case 'zendframework/zenddiagnostics':
+                return 'laminas/laminas-diagnostics';
+            case 'zendframework/zendoauth':
+                return 'laminas/laminas-oauth';
+            case 'zendframework/zendservice-recaptcha':
+                return 'laminas/laminas-recaptcha';
+            case 'zendframework/zendservice-twitter':
+                return 'laminas/laminas-twitter';
+            case 'zendframework/zendxml':
+                return 'laminas/laminas-xml';
+            case 'zendframework/zend-expressive':
+                return 'mezzio/mezzio';
+            case 'zendframework/zend-problem-details':
+                return 'mezzio/mezzio-problem-details';
+            case 'zfcampus/zf-apigility':
+                return 'laminas-api-tools/api-tools';
+            case 'zfcampus/zf-composer-autoloading':
+                return 'laminas/laminas-composer-autoloading';
+            case 'zfcampus/zf-development-mode':
+                return 'laminas/laminas-development-mode';
+            // All other packages:
+            default:
+                if (preg_match('#^zendframework/zend-expressive-zend(?<name>.*)$#', $name, $matches)) {
+                    return sprintf('mezzio/mezzio-laminas%s', $matches['name']);
+                }
+                if (preg_match('#^zendframework/zend-expressive-(?<name>.*)$#', $name, $matches)) {
+                    return sprintf('mezzio/mezzio-%s', $matches['name']);
+                }
+                if (preg_match('#^zfcampus/zf-apigility-(?<name>.*)$#', $name, $matches)) {
+                    return sprintf('laminas-api-tools/api-tools-%s', $matches['name']);
+                }
+                if (preg_match('#^zfcampus/zf-(?<name>.*)$#', $name, $matches)) {
+                    return sprintf('laminas-api-tools/api-tools-%s', $matches['name']);
+                }
+                if (preg_match('#^zendframework/zend-(?<name>.*)$#', $name, $matches)) {
+                    return sprintf('laminas/laminas-%s', $matches['name']);
+                }
+                return $name;
+        }
+    }
+
+    /**
+     * @param string $name Original package name
+     * @return bool
+     */
+    public function isZendPackage($name)
+    {
+        if (! preg_match('#^(zendframework|zfcampus)/#', $name)) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/RewriterInterface.php
+++ b/src/RewriterInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-dependency-plugin for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-dependency-plugin/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-dependency-plugin/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Laminas\DependencyPlugin;
+
+use Composer\Composer;
+use Composer\Installer\PackageEvent;
+use Composer\IO\IOInterface;
+use Composer\Plugin\PreCommandRunEvent;
+
+interface RewriterInterface
+{
+    public function activate(Composer $composer, IOInterface $io);
+
+    /**
+     * When a ZF package is requested, replace with the Laminas variant.
+     *
+     * When a `require` operation is requested, and a ZF package is detected,
+     * this listener will replace the argument with the equivalent Laminas
+     * package. This ensures that the `composer.json` file is written to
+     * reflect the package installed.
+     */
+    public function onPreCommandRun(PreCommandRunEvent $event);
+
+    /**
+     * When a ZF package is installed or updated, ensure that its being replaced after installation/update is finished.
+     */
+    public function onPrePackageInstallOrUpdate(PackageEvent $event);
+}

--- a/test/DependencyRewriterPluginDelegatorTest.php
+++ b/test/DependencyRewriterPluginDelegatorTest.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * @see       https://github.com/laminas/laminas-dependency-plugin for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-dependency-plugin/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-dependency-plugin/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace LaminasTest\DependencyPlugin;
+
+use Composer\Composer;
+use Composer\Installer\InstallerEvent;
+use Composer\Installer\PackageEvent;
+use Composer\IO\IOInterface;
+use Composer\Plugin\PreCommandRunEvent;
+use Composer\Plugin\PrePoolCreateEvent;
+use Composer\Script\Event;
+use Generator;
+use Laminas\DependencyPlugin\AbstractDependencyRewriter;
+use Laminas\DependencyPlugin\AutoloadDumpCapableInterface;
+use Laminas\DependencyPlugin\DependencyRewriterPluginDelegator;
+use Laminas\DependencyPlugin\DependencySolvingCapableInterface;
+use Laminas\DependencyPlugin\PoolCapableInterface;
+use Laminas\DependencyPlugin\RewriterInterface;
+use PHPUnit\Framework\TestCase;
+
+use function call_user_func;
+
+final class DependencyRewriterPluginDelegatorTest extends TestCase
+{
+    public function testWillTriggerActivate() : void
+    {
+        $composer = $this->createMock(Composer::class);
+        $io = $this->createMock(IOInterface::class);
+
+        $rewriter = $this->createMock(AbstractDependencyRewriter::class);
+        $delegator = new DependencyRewriterPluginDelegator($rewriter);
+        $rewriter
+            ->expects($this->once())
+            ->method('activate')
+            ->with($composer, $io);
+
+        $delegator->activate($composer, $io);
+    }
+
+    /**
+     * @dataProvider eventsToForward
+     *
+     * @param string $event
+     */
+    public function testWillForwardEvents(string $rewriter, string $eventMethod, $event) : void
+    {
+        $event = $this->createMock($event);
+        $rewriter = $this->createMock($rewriter);
+        $rewriter
+            ->expects($this->once())
+            ->method($eventMethod)
+            ->with($event);
+
+        self::assertInstanceOf(RewriterInterface::class, $rewriter);
+        $delegator = new DependencyRewriterPluginDelegator($rewriter);
+
+        call_user_func([$delegator, $eventMethod], $event);
+    }
+
+    public function eventsToForward() : Generator
+    {
+        yield 'onPreDependenciesSolving' => [
+            DependencySolvingCapableInterface::class,
+            'onPreDependenciesSolving',
+            InstallerEvent::class,
+        ];
+        yield 'onPrePackageInstallOrUpdate' => [
+            RewriterInterface::class,
+            'onPrePackageInstallOrUpdate',
+            PackageEvent::class,
+        ];
+        yield 'onPreCommandRun' => [
+            RewriterInterface::class,
+            'onPreCommandRun',
+            PreCommandRunEvent::class,
+        ];
+        yield 'onPrePoolCreate' => [
+            PoolCapableInterface::class,
+            'onPrePoolCreate',
+            PrePoolCreateEvent::class,
+        ];
+        yield 'onPostAutoloadDump' => [
+            AutoloadDumpCapableInterface::class,
+            'onPostAutoloadDump',
+            Event::class,
+        ];
+    }
+}

--- a/test/DependencyRewriterPluginDelegatorTest.php
+++ b/test/DependencyRewriterPluginDelegatorTest.php
@@ -25,8 +25,6 @@ use Laminas\DependencyPlugin\PoolCapableInterface;
 use Laminas\DependencyPlugin\RewriterInterface;
 use PHPUnit\Framework\TestCase;
 
-use function call_user_func;
-
 final class DependencyRewriterPluginDelegatorTest extends TestCase
 {
     public function testWillTriggerActivate() : void
@@ -61,7 +59,7 @@ final class DependencyRewriterPluginDelegatorTest extends TestCase
         self::assertInstanceOf(RewriterInterface::class, $rewriter);
         $delegator = new DependencyRewriterPluginDelegator($rewriter);
 
-        call_user_func([$delegator, $eventMethod], $event);
+        $delegator->$eventMethod($event);
     }
 
     public function eventsToForward() : Generator

--- a/test/DependencyRewriterV1Test.php
+++ b/test/DependencyRewriterV1Test.php
@@ -23,6 +23,7 @@ use Composer\Repository\RepositoryManager;
 use Laminas\DependencyPlugin\DependencyRewriterV1;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use ReflectionProperty;
 use Symfony\Component\Console\Input\InputInterface;
@@ -32,6 +33,8 @@ use function version_compare;
 
 final class DependencyRewriterV1Test extends TestCase
 {
+    use ProphecyTrait;
+
     /** @var Composer|ObjectProphecy */
     private $composer;
 

--- a/test/DependencyRewriterV2Test.php
+++ b/test/DependencyRewriterV2Test.php
@@ -729,9 +729,9 @@ TXT
              ->willReturn($config->reveal());
 
         $this->io
-            ->isDebug()
-            ->willReturn(false)
-            ->shouldBeCalled();
+             ->isDebug()
+             ->willReturn(false)
+             ->shouldBeCalled();
 
         $event = $this->prophesize(PrePoolCreateEvent::class);
         $event

--- a/test/DependencyRewriterV2Test.php
+++ b/test/DependencyRewriterV2Test.php
@@ -725,6 +725,11 @@ TXT
              ->getConfig()
              ->willReturn($config->reveal());
 
+        $this->io
+            ->isDebug()
+            ->willReturn(false)
+            ->shouldBeCalled();
+
         $event = $this->prophesize(PrePoolCreateEvent::class);
         $event
             ->getUnacceptableFixedPackages()

--- a/test/DependencyRewriterV2Test.php
+++ b/test/DependencyRewriterV2Test.php
@@ -30,6 +30,7 @@ use Laminas\DependencyPlugin\DependencyRewriterV2;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use ReflectionProperty;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -49,6 +50,8 @@ use const JSON_THROW_ON_ERROR;
 
 final class DependencyRewriterV2Test extends TestCase
 {
+    use ProphecyTrait;
+
     /** @var Composer|ObjectProphecy */
     private $composer;
 

--- a/test/DependencyRewriterV2Test.php
+++ b/test/DependencyRewriterV2Test.php
@@ -1,0 +1,1099 @@
+<?php
+/**
+ * @see       https://github.com/laminas/laminas-dependency-plugin for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-dependency-plugin/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-dependency-plugin/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace LaminasTest\DependencyPlugin;
+
+use Composer\Composer;
+use Composer\Config;
+use Composer\Console\Application;
+use Composer\DependencyResolver\Operation;
+use Composer\Installer\InstallationManager;
+use Composer\Installer\PackageEvent;
+use Composer\IO\IOInterface;
+use Composer\Package\Package;
+use Composer\Package\PackageInterface;
+use Composer\Package\RootPackageInterface;
+use Composer\Plugin\PluginInterface;
+use Composer\Plugin\PreCommandRunEvent;
+use Composer\Plugin\PrePoolCreateEvent;
+use Composer\Repository\InstalledFilesystemRepository;
+use Composer\Repository\RepositoryManager;
+use Composer\Script\Event;
+use Generator;
+use Laminas\DependencyPlugin\DependencyRewriterV2;
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+use ReflectionProperty;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputInterface;
+
+use function array_combine;
+use function array_keys;
+use function array_map;
+use function get_class;
+use function in_array;
+use function json_decode;
+use function json_encode;
+use function sprintf;
+use function version_compare;
+
+use const JSON_THROW_ON_ERROR;
+
+final class DependencyRewriterV2Test extends TestCase
+{
+    /** @var Composer|ObjectProphecy */
+    private $composer;
+
+    /** @var IOInterface|ObjectProphecy */
+    private $io;
+
+    /** @var DependencyRewriterV2 */
+    private $plugin;
+
+    /**
+     * @var InstallationManager|ObjectProphecy
+     */
+    private $installationManager;
+
+    /**
+     * @var ObjectProphecy|RepositoryManager
+     */
+    private $repositoryManager;
+
+    /**
+     * @var InstalledFilesystemRepository|ObjectProphecy
+     */
+    private $localRepository;
+
+    public function setUp() : void
+    {
+        if (! version_compare(PluginInterface::PLUGIN_API_VERSION, '2.0.0', 'ge')) {
+            $this->markTestSkipped('Only executing these tests for composer v2');
+        }
+
+        $this->composer = $this->prophesize(Composer::class);
+        $this->installationManager = $this->prophesize(InstallationManager::class);
+        $this->composer
+             ->getInstallationManager()
+             ->willReturn($this->installationManager->reveal());
+
+        $this->repositoryManager = $this->prophesize(RepositoryManager::class);
+        $this->localRepository = $this->prophesize(InstalledFilesystemRepository::class);
+        $this->repositoryManager
+             ->getLocalRepository()
+             ->willReturn($this->localRepository->reveal());
+
+        $this->composer
+             ->getRepositoryManager()
+             ->willReturn($this->repositoryManager->reveal());
+
+        $this->io = $this->prophesize(IOInterface::class);
+
+        $this->plugin = new DependencyRewriterV2();
+    }
+
+    public function activatePlugin(DependencyRewriterV2 $plugin) : void
+    {
+        $this->io
+             ->write(
+                 Argument::containingString('Activating Laminas\DependencyPlugin\DependencyRewriterV2'),
+                 true,
+                 IOInterface::DEBUG
+             )
+             ->shouldBeCalled();
+
+        $plugin->activate($this->composer->reveal(), $this->io->reveal());
+    }
+
+    public function testOnPreCommandRunDoesNothingIfCommandIsNotRequire() : void
+    {
+        $this->activatePlugin($this->plugin);
+
+        $this->io
+             ->write(
+                 Argument::containingString(
+                     'In Laminas\DependencyPlugin\DependencyRewriterV2::onPreCommandRun'
+                 ),
+                 true,
+                 IOInterface::DEBUG
+             )
+             ->shouldBeCalled();
+
+        $event = $this->prophesize(PreCommandRunEvent::class);
+        $event->getCommand()->willReturn('remove')->shouldBeCalled();
+        $event->getInput()->shouldNotBeCalled();
+
+        $this->assertNull($this->plugin->onPreCommandRun($event->reveal()));
+    }
+
+    public function testOnPreCommandDoesNotRewriteNonZFPackageArguments() : void
+    {
+        $this->activatePlugin($this->plugin);
+
+        $this->io
+             ->write(
+                 Argument::containingString(
+                     'In Laminas\DependencyPlugin\DependencyRewriterV2::onPreCommandRun'
+                 ),
+                 true,
+                 IOInterface::DEBUG
+             )
+             ->shouldBeCalled();
+
+        $event = $this->prophesize(PreCommandRunEvent::class);
+        $event->getCommand()->willReturn('require')->shouldBeCalled();
+
+        $input = $this->prophesize(InputInterface::class);
+        $input
+            ->hasArgument('packages')
+            ->willReturn(true);
+
+        $input
+            ->getArgument('packages')
+            ->willReturn(['symfony/console', 'phpunit/phpunit'])
+            ->shouldBeCalled();
+        $input
+            ->setArgument(
+                'packages',
+                ['symfony/console', 'phpunit/phpunit']
+            )
+            ->shouldBeCalled();
+
+        $event->getInput()->will([$input, 'reveal']);
+
+        $this->assertNull($this->plugin->onPreCommandRun($event->reveal()));
+    }
+
+    public function testOnPreCommandRewritesZFPackageArguments() : void
+    {
+        $this->activatePlugin($this->plugin);
+
+        $this->io
+             ->write(
+                 Argument::containingString(
+                     'In Laminas\DependencyPlugin\DependencyRewriterV2::onPreCommandRun'
+                 ),
+                 true,
+                 IOInterface::DEBUG
+             )
+             ->shouldBeCalled();
+
+        $event = $this->prophesize(PreCommandRunEvent::class);
+        $event->getCommand()->willReturn('require')->shouldBeCalled();
+
+        $input = $this->prophesize(InputInterface::class);
+        $input
+            ->hasArgument('packages')
+            ->willReturn(true);
+
+        $input
+            ->getArgument('packages')
+            ->willReturn([
+                'zendframework/zend-form',
+                'zfcampus/zf-content-negotiation',
+                'zendframework/zend-expressive-hal',
+                'zendframework/zend-expressive-zendviewrenderer',
+            ])
+            ->shouldBeCalled();
+        $input
+            ->setArgument(
+                'packages',
+                [
+                    'laminas/laminas-form',
+                    'laminas-api-tools/api-tools-content-negotiation',
+                    'mezzio/mezzio-hal',
+                    'mezzio/mezzio-laminasviewrenderer',
+                ]
+            )
+            ->shouldBeCalled();
+
+        $event->getInput()->will([$input, 'reveal']);
+
+        $this->io
+             ->write(
+                 Argument::containingString(
+                     'Changing package in current command from zendframework/zend-form to laminas/laminas-form'
+                 ),
+                 true,
+                 IOInterface::DEBUG
+             )
+             ->shouldBeCalled();
+
+        $this->io
+             ->write(
+                 Argument::containingString(
+                     'Changing package in current command from zfcampus/zf-content-negotiation to'
+                     . ' laminas-api-tools/api-tools-content-negotiation'
+                 ),
+                 true,
+                 IOInterface::DEBUG
+             )
+             ->shouldBeCalled();
+
+        $this->io
+             ->write(
+                 Argument::containingString(
+                     'Changing package in current command from zendframework/zend-expressive-hal to mezzio/mezzio-hal'
+                 ),
+                 true,
+                 IOInterface::DEBUG
+             )
+             ->shouldBeCalled();
+
+        $this->io
+             ->write(
+                 Argument::containingString(
+                     'Changing package in current command from zendframework/zend-expressive-zendviewrenderer'
+                     . ' to mezzio/mezzio-laminasviewrenderer'
+                 ),
+                 true,
+                 IOInterface::DEBUG
+             )
+             ->shouldBeCalled();
+
+        $this->assertNull($this->plugin->onPreCommandRun($event->reveal()));
+    }
+
+    public function testPrePackageInstallExitsEarlyForUnsupportedOperations() : void
+    {
+        $this->activatePlugin($this->plugin);
+
+        $event = $this->prophesize(PackageEvent::class);
+        $operation = $this->prophesize(Operation\UninstallOperation::class);
+
+        $event->getOperation()->will([$operation, 'reveal'])->shouldBeCalled();
+
+        $this->io
+             ->write(
+                 Argument::containingString(
+                     'In ' . DependencyRewriterV2::class . '::onPrePackageInstallOrUpdate'
+                 ),
+                 true,
+                 IOInterface::DEBUG
+             )
+             ->shouldBeCalled();
+
+        $this->io
+             ->write(
+                 Argument::containingString(
+                     'Exiting; operation of type ' . get_class($operation->reveal()) . ' not supported'
+                 ),
+                 true,
+                 IOInterface::DEBUG
+             )
+             ->shouldBeCalled();
+
+        $this->assertNull($this->plugin->onPrePackageInstallOrUpdate($event->reveal()));
+    }
+
+    public function testPrePackageInstallExitsEarlyForNonZFPackages() : void
+    {
+        $this->activatePlugin($this->plugin);
+
+        $event = $this->prophesize(PackageEvent::class);
+        $operation = $this->prophesize(Operation\InstallOperation::class);
+        $package = $this->prophesize(PackageInterface::class);
+
+        $event->getOperation()->will([$operation, 'reveal'])->shouldBeCalled();
+        $operation->getPackage()->will([$package, 'reveal'])->shouldBeCalled();
+        $package->getName()->willReturn('symfony/console')->shouldBeCalled();
+
+        $this->io
+             ->write(
+                 Argument::containingString(
+                     'In ' . DependencyRewriterV2::class . '::onPrePackageInstallOrUpdate'
+                 ),
+                 true,
+                 IOInterface::DEBUG
+             )
+             ->shouldBeCalled();
+
+        $this->io
+             ->write(
+                 Argument::containingString(
+                     'Exiting; operation of type ' . get_class($operation->reveal()) . ' not supported'
+                 ),
+                 true,
+                 IOInterface::DEBUG
+             )
+             ->shouldNotBeCalled();
+
+        $this->io
+             ->write(
+                 Argument::containingString(
+                     'Exiting; package "symfony/console" does not have a replacement'
+                 ),
+                 true,
+                 IOInterface::DEBUG
+             )
+             ->shouldBeCalled();
+
+        $this->assertNull($this->plugin->onPrePackageInstallOrUpdate($event->reveal()));
+    }
+
+    public function testPrePackageInstallExitsEarlyForZFPackagesWithoutReplacements() : void
+    {
+        $this->activatePlugin($this->plugin);
+
+        $event = $this->prophesize(PackageEvent::class);
+        $operation = $this->prophesize(Operation\UpdateOperation::class);
+        $package = $this->prophesize(PackageInterface::class);
+
+        $event->getOperation()->will([$operation, 'reveal'])->shouldBeCalled();
+        $operation->getTargetPackage()->will([$package, 'reveal'])->shouldBeCalled();
+        $package->getName()->willReturn('zendframework/zend-version')->shouldBeCalled();
+
+        $this->io
+             ->write(
+                 Argument::containingString(
+                     'In ' . DependencyRewriterV2::class . '::onPrePackageInstallOrUpdate'
+                 ),
+                 true,
+                 IOInterface::DEBUG
+             )
+             ->shouldBeCalled();
+
+        $this->io
+             ->write(
+                 Argument::containingString(
+                     'Exiting; operation of type ' . get_class($operation->reveal()) . ' not supported'
+                 ),
+                 true,
+                 IOInterface::DEBUG
+             )
+             ->shouldNotBeCalled();
+
+        $this->io
+             ->write(
+                 Argument::containingString(
+                     'Exiting; package "zendframework/zend-version" does not have a replacement'
+                 ),
+                 true,
+                 IOInterface::DEBUG
+             )
+             ->shouldNotBeCalled();
+
+        $this->io
+             ->write(
+                 Argument::containingString(
+                     'Exiting; while package "zendframework/zend-version" is a ZF package,'
+                     . ' it does not have a replacement'
+                 ),
+                 true,
+                 IOInterface::DEBUG
+             )
+             ->shouldBeCalled();
+
+        $this->assertNull($this->plugin->onPrePackageInstallOrUpdate($event->reveal()));
+    }
+
+    public function testPrePackageInstallExitsEarlyForZFPackagesWithoutReplacementsForSpecificVersion() : void
+    {
+        $this->activatePlugin($this->plugin);
+
+        $event = $this->prophesize(PackageEvent::class);
+        $operation = $this->prophesize(Operation\UpdateOperation::class);
+        $package = $this->prophesize(PackageInterface::class);
+        $repositoryManager = $this->prophesize(RepositoryManager::class);
+
+        $event->getOperation()->will([$operation, 'reveal'])->shouldBeCalled();
+        $operation->getTargetPackage()->will([$package, 'reveal'])->shouldBeCalled();
+        $package->getName()->willReturn('zendframework/zend-mvc')->shouldBeCalled();
+        $package->getVersion()->willReturn('4.0.0')->shouldBeCalled();
+        $this->composer->getRepositoryManager()->will([$repositoryManager, 'reveal'])->shouldBeCalled();
+        $repositoryManager
+            ->findPackage('laminas/laminas-mvc', '4.0.0')
+            ->willReturn(null)
+            ->shouldBeCalled();
+
+        $this->io
+             ->write(
+                 Argument::containingString(
+                     'In ' . DependencyRewriterV2::class . '::onPrePackageInstallOrUpdate'
+                 ),
+                 true,
+                 IOInterface::DEBUG
+             )
+             ->shouldBeCalled();
+
+        $this->io
+             ->write(
+                 Argument::containingString(
+                     'Exiting; operation of type ' . get_class($operation->reveal()) . ' not supported'
+                 ),
+                 true,
+                 IOInterface::DEBUG
+             )
+             ->shouldNotBeCalled();
+
+        $this->io
+             ->write(
+                 Argument::containingString(
+                     'Exiting; package "zendframework/zend-version" does not have a replacement'
+                 ),
+                 true,
+                 IOInterface::DEBUG
+             )
+             ->shouldNotBeCalled();
+
+        $this->io
+             ->write(
+                 Argument::containingString(
+                     'Exiting; while package "zendframework/zend-version" is a ZF package,'
+                     . ' it does not have a replacement'
+                 ),
+                 true,
+                 IOInterface::DEBUG
+             )
+             ->shouldNotBeCalled();
+
+        $this->io
+             ->write(
+                 Argument::containingString(
+                     'Exiting; no replacement package found for package "laminas/laminas-mvc" with version 4.0.0'
+                 ),
+                 true,
+                 IOInterface::DEBUG
+             )
+             ->shouldBeCalled();
+
+        $this->assertNull($this->plugin->onPrePackageInstallOrUpdate($event->reveal()));
+    }
+
+    public function testPrePackageUpdatesPackageNameWhenReplacementExists() : void
+    {
+        $this->activatePlugin($this->plugin);
+
+        $event = $this->prophesize(PackageEvent::class);
+        $original = new Package('zendframework/zend-mvc', '3.1.0', '3.1.1');
+        $package = new Package('zendframework/zend-mvc', '3.1.1', '3.1.1');
+        $operation = new Operation\UpdateOperation($original, $package);
+
+        $replacementPackage = new Package('laminas/laminas-mvc', '3.1.1', '3.1.1');
+        $repositoryManager = $this->prophesize(RepositoryManager::class);
+
+        $event->getOperation()->willReturn($operation)->shouldBeCalled();
+        $this->composer->getRepositoryManager()->will([$repositoryManager, 'reveal'])->shouldBeCalled();
+        $repositoryManager
+            ->findPackage('laminas/laminas-mvc', '3.1.1')
+            ->willReturn($replacementPackage)
+            ->shouldBeCalled();
+
+        $this->io
+             ->write(
+                 Argument::containingString(
+                     'In ' . DependencyRewriterV2::class . '::onPrePackageInstallOrUpdate'
+                 ),
+                 true,
+                 IOInterface::DEBUG
+             )
+             ->shouldBeCalled();
+
+        $this->io
+             ->write(
+                 Argument::containingString(
+                     'Exiting; operation of type ' . get_class($operation) . ' not supported'
+                 ),
+                 true,
+                 IOInterface::DEBUG
+             )
+             ->shouldNotBeCalled();
+
+        $this->io
+             ->write(
+                 Argument::containingString(
+                     'Exiting; package "zendframework/zend-version" does not have a replacement'
+                 ),
+                 true,
+                 IOInterface::DEBUG
+             )
+             ->shouldNotBeCalled();
+
+        $this->io
+             ->write(
+                 Argument::containingString(
+                     'Exiting; while package "zendframework/zend-version" is a ZF package,'
+                     . ' it does not have a replacement'
+                 ),
+                 true,
+                 IOInterface::DEBUG
+             )
+             ->shouldNotBeCalled();
+
+        $this->io
+             ->write(
+                 Argument::containingString(
+                     'Exiting; no replacement package found for package "laminas/laminas-mvc"'
+                 ),
+                 true,
+                 IOInterface::DEBUG
+             )
+             ->shouldNotBeCalled();
+
+        $this->io
+             ->write(
+                 Argument::containingString(
+                     'Could replace package zendframework/zend-mvc with package laminas/laminas-mvc,'
+                     . ' using version 3.1.1'
+                 ),
+                 true,
+                 IOInterface::VERBOSE
+             )
+             ->shouldBeCalled();
+
+        $this->assertNull($this->plugin->onPrePackageInstallOrUpdate($event->reveal()));
+        $this->assertSame($package, $operation->getTargetPackage());
+        $this->assertTrue(
+            in_array($package, $this->plugin->getZendPackagesInstalled(), true),
+            'Plugin did not remembered zend package!'
+        );
+    }
+
+    public function testAutoloadDumpExitsEarlyIfNoZFPackageDetected() : void
+    {
+        $event = $this->prophesize(Event::class);
+        $event
+            ->getComposer()
+            ->shouldNotBeCalled();
+
+        $this->plugin->onPostAutoloadDump($event->reveal());
+    }
+
+    /**
+     * @dataProvider composerDefinitionWithZFPackageRequirement
+     */
+    public function testAutoloadDumpReplacesRootRequirementInComposerJson(
+        array $packages,
+        array $definition,
+        array $expectedDefinition
+    ) : void {
+        $factory = $this->createApplicationFactory();
+        $directory = vfsStream::setup();
+        $composerJson = vfsStream::newFile('composer.json')
+            ->withContent(json_encode($definition, JSON_THROW_ON_ERROR));
+        $directory->addChild($composerJson);
+
+        $this->io
+             ->isDebug()
+             ->willReturn(false)
+             ->shouldBeCalled();
+
+        $zendPackageNames = array_keys($packages);
+        $zendPackages = array_combine(
+            $zendPackageNames,
+            array_map(
+                function (string $packageName, string $version) : PackageInterface {
+                    $package = $this->createMock(PackageInterface::class);
+                    $package
+                        ->expects($this->any())
+                        ->method('getName')
+                        ->willReturn($packageName);
+
+                    $package
+                        ->expects($this->any())
+                        ->method('getVersion')
+                        ->willReturn($version);
+
+                    return $package;
+                },
+                $zendPackageNames,
+                $packages
+            )
+        );
+
+        $plugin = new DependencyRewriterV2($factory, $composerJson->url());
+        $reflection = new ReflectionProperty($plugin, 'zendPackagesInstalled');
+        $reflection->setAccessible(true);
+        $reflection->setValue($plugin, $zendPackages);
+        $this->activatePlugin($plugin);
+
+        foreach ($zendPackages as $packageName => $package) {
+            $this->io
+                 ->write(
+                     Argument::containingString(
+                         sprintf(
+                             'Package %s is a root requirement. laminas-dependency-plugin changes your composer.json'
+                             . ' to require laminas equivalent directly!',
+                             $packageName
+                         )
+                     ),
+                     true,
+                     IOInterface::NORMAL
+                 )
+                 ->shouldBeCalled();
+
+            $this->installationManager
+                 ->uninstall(
+                     Argument::exact($this->localRepository),
+                     Argument::that(
+                         static function (Operation\UninstallOperation $operation) use ($package) : bool {
+                             return $operation->getPackage() === $package;
+                         }
+                     )
+                 )
+                 ->shouldBeCalled();
+        }
+
+        $event = $this->prophesize(Event::class);
+        $event
+            ->getComposer()
+            ->willReturn($this->composer->reveal());
+
+        $plugin->onPostAutoloadDump($event->reveal());
+
+        $decoded = json_decode($composerJson->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertEquals($expectedDefinition, $decoded);
+    }
+
+    private function createApplicationFactory() : callable
+    {
+        return function () : Application {
+            $mock = $this->createMock(Application::class);
+            $mock
+                ->expects($this->once())
+                ->method('setAutoExit')
+                ->with(false);
+
+            $mock
+                ->expects($this->once())
+                ->method('run')
+                ->with($this->callback(static function (ArrayInput $input) : bool {
+                    self::assertEquals('update', $input->getParameterOption('command'));
+                    self::assertTrue($input->getParameterOption('--lock'), '--lock should be passed');
+                    self::assertTrue($input->getParameterOption('--no-scripts'), '--no-scripts should be passed');
+                    self::assertIsString($input->getParameterOption('--working-dir'), 'Missing working-dir argument');
+                    return true;
+                }));
+
+            return $mock;
+        };
+    }
+
+    public function testPrePoolCreateEarlyExitsIfNoZendPackageIsInstalled() : void
+    {
+        $this->activatePlugin($this->plugin);
+        $this->io
+             ->write(
+                 Argument::containingString('In Laminas\DependencyPlugin\DependencyRewriterV2::onPrePoolCreate'),
+                 true,
+                 IOInterface::NORMAL
+             )
+             ->shouldBeCalled();
+
+        $rootPackage = $this->prophesize(RootPackageInterface::class);
+        $this->composer
+             ->getPackage()
+             ->willReturn($rootPackage)
+             ->shouldBeCalled();
+
+        $vendor = vfsStream::setup();
+        $installed = vfsStream::newFile('installed.json')
+            ->withContent(<<<TXT
+{
+    "packages": [
+        {
+            "name": "foo/bar",
+            "version": "1.0",
+            "version_normalized": "1.0.0.0",
+            "type": "metapackage",
+            "install-path": null
+        }
+    ],
+    "dev": true
+}
+TXT
+            );
+        $composer = vfsStream::newDirectory('composer');
+        $vendor->addChild($composer);
+        $composer->addChild($installed);
+
+        $config = $this->prophesize(Config::class);
+        $config
+            ->get('vendor-dir')
+            ->willReturn($vendor->url())
+            ->shouldBeCalled();
+
+        $this->composer
+             ->getConfig()
+             ->willReturn($config->reveal());
+
+        $event = $this->prophesize(PrePoolCreateEvent::class);
+        $event
+            ->getUnacceptableFixedPackages()
+            ->shouldNotBeCalled();
+
+        $this->plugin->onPrePoolCreate($event->reveal());
+    }
+
+    public function testPrePoolCreateWillIgnoreIgnoredPackages() : void
+    {
+        $this->activatePlugin($this->plugin);
+        $this->io
+             ->write(
+                 Argument::containingString('In Laminas\DependencyPlugin\DependencyRewriterV2::onPrePoolCreate'),
+                 true,
+                 IOInterface::NORMAL
+             )
+             ->shouldBeCalled();
+
+        $rootPackage = $this->prophesize(RootPackageInterface::class);
+        $this->composer
+             ->getPackage()
+             ->willReturn($rootPackage)
+             ->shouldBeCalled();
+
+        $vendor = vfsStream::setup();
+        $installed = vfsStream::newFile('installed.json')
+            ->withContent(<<<TXT
+{
+    "packages": [
+        {
+            "name": "zendframework/zend-debug",
+            "version": "1.0",
+            "version_normalized": "1.0.0.0",
+            "type": "metapackage",
+            "install-path": null
+        }
+    ],
+    "dev": true
+}
+TXT
+            );
+        $composer = vfsStream::newDirectory('composer');
+        $vendor->addChild($composer);
+        $composer->addChild($installed);
+
+        $config = $this->prophesize(Config::class);
+        $config
+            ->get('vendor-dir')
+            ->willReturn($vendor->url())
+            ->shouldBeCalled();
+
+        $this->composer
+             ->getConfig()
+             ->willReturn($config->reveal());
+
+        $event = $this->prophesize(PrePoolCreateEvent::class);
+        $event
+            ->getUnacceptableFixedPackages()
+            ->willReturn([])
+            ->shouldBeCalled();
+
+        $package = $this->createMock(PackageInterface::class);
+        $package
+            ->expects($this->any())
+            ->method('getName')
+            ->willReturn('zendframework/zend-debug');
+
+        $packages = [
+            $package,
+        ];
+
+        $event
+            ->getPackages()
+            ->willReturn($packages)
+            ->shouldBeCalled();
+
+        $event
+            ->setUnacceptableFixedPackages([])
+            ->shouldBeCalled();
+
+        $event
+            ->setPackages($packages)
+            ->shouldBeCalled();
+
+        $this->repositoryManager
+             ->findPackage()
+             ->shouldNotBeCalled();
+
+        $this->io->isDebug()->willReturn(false)->shouldBeCalled();
+
+        $this->plugin->onPrePoolCreate($event->reveal());
+    }
+
+    public function testPrePoolCreateWillIgnoreUnavailablePackages() : void
+    {
+        $this->activatePlugin($this->plugin);
+        $this->io
+             ->write(
+                 Argument::containingString('In Laminas\DependencyPlugin\DependencyRewriterV2::onPrePoolCreate'),
+                 true,
+                 IOInterface::NORMAL
+             )
+             ->shouldBeCalled();
+
+        $rootPackage = $this->prophesize(RootPackageInterface::class);
+        $this->composer
+             ->getPackage()
+             ->willReturn($rootPackage)
+             ->shouldBeCalled();
+
+        $vendor = vfsStream::setup();
+        $installed = vfsStream::newFile('installed.json')
+            ->withContent(<<<TXT
+{
+    "packages": [
+        {
+            "name": "zendframework/zend-stdlib",
+            "version": "1.0",
+            "version_normalized": "1.0.0.0",
+            "type": "metapackage",
+            "install-path": null
+        }
+    ],
+    "dev": true
+}
+TXT
+            );
+        $composer = vfsStream::newDirectory('composer');
+        $vendor->addChild($composer);
+        $composer->addChild($installed);
+
+        $config = $this->prophesize(Config::class);
+        $config
+            ->get('vendor-dir')
+            ->willReturn($vendor->url())
+            ->shouldBeCalled();
+
+        $this->composer
+             ->getConfig()
+             ->willReturn($config->reveal());
+
+        $event = $this->prophesize(PrePoolCreateEvent::class);
+        $event
+            ->getUnacceptableFixedPackages()
+            ->willReturn([])
+            ->shouldBeCalled();
+
+        $package = $this->createMock(PackageInterface::class);
+        $package
+            ->expects($this->any())
+            ->method('getName')
+            ->willReturn('zendframework/zend-stdlib');
+
+        $package
+            ->expects($this->any())
+            ->method('getVersion')
+            ->willReturn('1.0');
+
+        $packages = [
+            $package,
+        ];
+
+        $event
+            ->getPackages()
+            ->willReturn($packages)
+            ->shouldBeCalled();
+
+        $event
+            ->setUnacceptableFixedPackages([])
+            ->shouldBeCalled();
+
+        $event
+            ->setPackages($packages)
+            ->shouldBeCalled();
+
+        $this->repositoryManager
+             ->findPackage('laminas/laminas-stdlib', '1.0')
+             ->willReturn(null)
+             ->shouldBeCalled();
+
+        $this->io->isDebug()->willReturn(false)->shouldBeCalled();
+
+        $this->plugin->onPrePoolCreate($event->reveal());
+    }
+
+    public function testPrePoolCreateWillSlipstreamPackage() : void
+    {
+        $this->activatePlugin($this->plugin);
+        $this->io
+             ->write(
+                 Argument::containingString('In Laminas\DependencyPlugin\DependencyRewriterV2::onPrePoolCreate'),
+                 true,
+                 IOInterface::NORMAL
+             )
+             ->shouldBeCalled();
+
+        $rootPackage = $this->prophesize(RootPackageInterface::class);
+        $this->composer
+             ->getPackage()
+             ->willReturn($rootPackage)
+             ->shouldBeCalled();
+
+        $vendor = vfsStream::setup();
+        $installed = vfsStream::newFile('installed.json')
+            ->withContent(<<<TXT
+{
+    "packages": [
+        {
+            "name": "zendframework/zend-stdlib",
+            "version": "1.0",
+            "version_normalized": "1.0.0.0",
+            "type": "metapackage",
+            "install-path": null
+        }
+    ],
+    "dev": true
+}
+TXT
+            );
+        $composer = vfsStream::newDirectory('composer');
+        $vendor->addChild($composer);
+        $composer->addChild($installed);
+
+        $config = $this->prophesize(Config::class);
+        $config
+            ->get('vendor-dir')
+            ->willReturn($vendor->url())
+            ->shouldBeCalled();
+
+        $this->composer
+             ->getConfig()
+             ->willReturn($config->reveal());
+
+        $event = $this->prophesize(PrePoolCreateEvent::class);
+        $event
+            ->getUnacceptableFixedPackages()
+            ->willReturn([])
+            ->shouldBeCalled();
+
+        $package = $this->createMock(PackageInterface::class);
+        $package
+            ->expects($this->any())
+            ->method('getName')
+            ->willReturn('zendframework/zend-stdlib');
+
+        $package
+            ->expects($this->any())
+            ->method('getVersion')
+            ->willReturn('1.0');
+
+        $packages = [
+            $package,
+        ];
+
+        $event
+            ->getPackages()
+            ->willReturn($packages)
+            ->shouldBeCalled();
+
+        $replacement = $this->createMock(PackageInterface::class);
+
+        $this->repositoryManager
+             ->findPackage('laminas/laminas-stdlib', '1.0')
+             ->willReturn($replacement)
+             ->shouldBeCalled();
+
+        $event
+            ->setUnacceptableFixedPackages([$package])
+            ->shouldBeCalled();
+
+        $event
+            ->setPackages([$replacement])
+            ->shouldBeCalled();
+
+        $this->io->isDebug()->willReturn(false)->shouldBeCalled();
+        $this->io
+             ->write(
+                 Argument::containingString(
+                     'Slipstreaming zendframework/zend-stdlib => laminas/laminas-stdlib',
+                 ),
+                 true,
+                 IOInterface::NORMAL
+             )
+             ->shouldBeCalled();
+
+        $this->plugin->onPrePoolCreate($event->reveal());
+    }
+
+    public function composerDefinitionWithZFPackageRequirement() : Generator
+    {
+        yield 'require' => [
+            [
+                'zendframework/zend-stdlib' => '3.1.0',
+            ],
+            [
+                'require' => [
+                    'zendframework/zend-stdlib' => '^3.1',
+                ],
+            ],
+            [
+                'require' => [
+                    'laminas/laminas-stdlib' => '^3.1',
+                ],
+            ],
+        ];
+
+        yield 'require-dev' => [
+            [
+                'zendframework/zend-stdlib' => '3.1.0',
+            ],
+            [
+                'require-dev' => [
+                    'zendframework/zend-stdlib' => '^3.1',
+                ],
+            ],
+            [
+                'require-dev' => [
+                    'laminas/laminas-stdlib' => '^3.1',
+                ],
+            ],
+        ];
+
+        yield 'require with sort packages' => [
+            [
+                'zendframework/zend-stdlib' => '3.1.0',
+            ],
+            [
+                'config' => [
+                    'sort-packages' => true,
+                ],
+                'require' => [
+                    'psr/log' => '^1.0',
+                    'zendframework/zend-stdlib' => '^3.1',
+                ],
+            ],
+            [
+                'config' => [
+                    'sort-packages' => true,
+                ],
+                'require' => [
+                    'laminas/laminas-stdlib' => '^3.1',
+                    'psr/log' => '^1.0',
+                ],
+            ],
+        ];
+
+        yield 'require-dev with sort packages' => [
+            [
+                'zendframework/zend-stdlib' => '3.1.0',
+            ],
+            [
+                'config' => [
+                    'sort-packages' => true,
+                ],
+                'require-dev' => [
+                    'psr/log' => '^1.0',
+                    'zendframework/zend-stdlib' => '^3.1',
+                ],
+            ],
+            [
+                'config' => [
+                    'sort-packages' => true,
+                ],
+                'require-dev' => [
+                    'laminas/laminas-stdlib' => '^3.1',
+                    'psr/log' => '^1.0',
+                ],
+            ],
+        ];
+    }
+}

--- a/test/ReplacementsTest.php
+++ b/test/ReplacementsTest.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * @see       https://github.com/laminas/laminas-dependency-plugin for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-dependency-plugin/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-dependency-plugin/blob/master/LICENSE.md New BSD License
+ */
+
 declare(strict_types=1);
 
 namespace LaminasTest\DependencyPlugin;
@@ -9,13 +15,12 @@ use PHPUnit\Framework\TestCase;
 
 final class ReplacementsTest extends TestCase
 {
-
     /**
      * @var Replacements
      */
     private $replacements;
 
-    protected function setUp(): void
+    protected function setUp() : void
     {
         parent::setUp();
         $this->replacements = new Replacements();
@@ -26,13 +31,13 @@ final class ReplacementsTest extends TestCase
      * @dataProvider ignoredZFCampusPackages
      * @dataProvider zendToLaminasPackageNames
      */
-    public function testWillReplacePackageNames(string $packageName, string $expectedPackageName): void
+    public function testWillReplacePackageNames(string $packageName, string $expectedPackageName) : void
     {
         $transformedPackageName = $this->replacements->transformPackageName($packageName);
         $this->assertEquals($expectedPackageName, $transformedPackageName);
     }
 
-    public function zendToLaminasPackageNames(): Generator
+    public function zendToLaminasPackageNames() : Generator
     {
         yield 'zendframework/zenddiagnostics' => ['zendframework/zenddiagnostics', 'laminas/laminas-diagnostics'];
         yield 'zendframework/zendoauth' => ['zendframework/zendoauth', 'laminas/laminas-oauth'];
@@ -74,26 +79,26 @@ final class ReplacementsTest extends TestCase
             'laminas-api-tools/api-tools-doctrine',
         ];
 
-        yield 'zfcampus/zf-* regex' =>['zfcampus/zf-rest', 'laminas-api-tools/api-tools-rest'];
+        yield 'zfcampus/zf-* regex' => ['zfcampus/zf-rest', 'laminas-api-tools/api-tools-rest'];
 
         yield 'zendframework/zend-* regex' => ['zendframework/zend-config', 'laminas/laminas-config'];
     }
 
-    public function ignoredZendPackages(): Generator
+    public function ignoredZendPackages() : Generator
     {
         yield 'ignored zend-debug' => ['zendframework/zend-debug', 'zendframework/zend-debug'];
         yield 'ignored zend-version' => ['zendframework/zend-version', 'zendframework/zend-version'];
         yield 'ignored zendservice-apple-apns' => [
             'zendframework/zendservice-apple-apns',
-            'zendframework/zendservice-apple-apns'
+            'zendframework/zendservice-apple-apns',
         ];
         yield 'ignored zendservice-google-gcm' => [
             'zendframework/zendservice-google-gcm',
-            'zendframework/zendservice-google-gcm'
+            'zendframework/zendservice-google-gcm',
         ];
     }
 
-    public function ignoredZFCampusPackages(): Generator
+    public function ignoredZFCampusPackages() : Generator
     {
         yield 'ignored zf-apigility-example' => ['zfcampus/zf-apigility-example', 'zfcampus/zf-apigility-example'];
         yield 'ignored zf-angular' => ['zfcampus/zf-angular', 'zfcampus/zf-angular'];

--- a/test/ReplacementsTest.php
+++ b/test/ReplacementsTest.php
@@ -1,0 +1,103 @@
+<?php
+declare(strict_types=1);
+
+namespace LaminasTest\DependencyPlugin;
+
+use Generator;
+use Laminas\DependencyPlugin\Replacements;
+use PHPUnit\Framework\TestCase;
+
+final class ReplacementsTest extends TestCase
+{
+
+    /**
+     * @var Replacements
+     */
+    private $replacements;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->replacements = new Replacements();
+    }
+
+    /**
+     * @dataProvider ignoredZendPackages
+     * @dataProvider ignoredZFCampusPackages
+     * @dataProvider zendToLaminasPackageNames
+     */
+    public function testWillReplacePackageNames(string $packageName, string $expectedPackageName): void
+    {
+        $transformedPackageName = $this->replacements->transformPackageName($packageName);
+        $this->assertEquals($expectedPackageName, $transformedPackageName);
+    }
+
+    public function zendToLaminasPackageNames(): Generator
+    {
+        yield 'zendframework/zenddiagnostics' => ['zendframework/zenddiagnostics', 'laminas/laminas-diagnostics'];
+        yield 'zendframework/zendoauth' => ['zendframework/zendoauth', 'laminas/laminas-oauth'];
+        yield 'zendframework/zendservice-recaptcha' => [
+            'zendframework/zendservice-recaptcha',
+            'laminas/laminas-recaptcha',
+        ];
+        yield 'zendframework/zendservice-twitter' => ['zendframework/zendservice-twitter', 'laminas/laminas-twitter'];
+        yield 'zendframework/zendxml' => ['zendframework/zendxml', 'laminas/laminas-xml'];
+        yield 'zendframework/zend-expressive' => ['zendframework/zend-expressive', 'mezzio/mezzio'];
+        yield 'zendframework/zend-problem-details' => [
+            'zendframework/zend-problem-details',
+            'mezzio/mezzio-problem-details',
+        ];
+        yield 'zfcampus/zf-apigility' => ['zfcampus/zf-apigility', 'laminas-api-tools/api-tools'];
+        yield 'zfcampus/zf-composer-autoloading' => [
+            'zfcampus/zf-composer-autoloading',
+            'laminas/laminas-composer-autoloading',
+        ];
+        yield 'zfcampus/zf-development-mode' => ['zfcampus/zf-development-mode', 'laminas/laminas-development-mode'];
+
+        yield 'zendframework/zend-expressive-zend regex' => [
+            'zendframework/zend-expressive-zendviewrenderer',
+            'mezzio/mezzio-laminasviewrenderer',
+        ];
+
+        yield 'zendframework/zend-expressive-zend* regex' => [
+            'zendframework/zend-expressive-zendviewrenderer',
+            'mezzio/mezzio-laminasviewrenderer',
+        ];
+
+        yield 'zendframework/zend-expressive-* regex' => [
+            'zendframework/zend-expressive-router',
+            'mezzio/mezzio-router',
+        ];
+
+        yield 'zfcampus/zf-apigility-* regex' => [
+            'zfcampus/zf-apigility-doctrine',
+            'laminas-api-tools/api-tools-doctrine',
+        ];
+
+        yield 'zfcampus/zf-* regex' =>['zfcampus/zf-rest', 'laminas-api-tools/api-tools-rest'];
+
+        yield 'zendframework/zend-* regex' => ['zendframework/zend-config', 'laminas/laminas-config'];
+    }
+
+    public function ignoredZendPackages(): Generator
+    {
+        yield 'ignored zend-debug' => ['zendframework/zend-debug', 'zendframework/zend-debug'];
+        yield 'ignored zend-version' => ['zendframework/zend-version', 'zendframework/zend-version'];
+        yield 'ignored zendservice-apple-apns' => [
+            'zendframework/zendservice-apple-apns',
+            'zendframework/zendservice-apple-apns'
+        ];
+        yield 'ignored zendservice-google-gcm' => [
+            'zendframework/zendservice-google-gcm',
+            'zendframework/zendservice-google-gcm'
+        ];
+    }
+
+    public function ignoredZFCampusPackages(): Generator
+    {
+        yield 'ignored zf-apigility-example' => ['zfcampus/zf-apigility-example', 'zfcampus/zf-apigility-example'];
+        yield 'ignored zf-angular' => ['zfcampus/zf-angular', 'zfcampus/zf-angular'];
+        yield 'ignored zf-console' => ['zfcampus/zf-console', 'zfcampus/zf-console'];
+        yield 'ignored zf-deploy' => ['zfcampus/zf-deploy', 'zfcampus/zf-deploy'];
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| New Feature   | yes

### Description

While trying to migrate to composer 2.0, I've tried many ways on how to achieve the functionality of the current plugin.

The current plugin "slip streams" into the composer process, which is probably the best solution to solve the following scenarios:

- If 3rd-party library has a zend-dependency and updates to laminas, there wont be any changes to the project as the laminas package is already required.

- If a 3rd-party library has a zend-dependency and requires a newer zend-dependency, the project will just upgrade to the laminas equivalent. No further action needed.

- If a 3rd-party library totally drops a zend-dependency and does not need the laminas equivalent, the slip-streamed laminas dependency will automatically being removed from the project if its not needed anymore.

I came up with a way in #15 which should have introduced some more user interactions. The main idea was:

If a 3rd-party library has a zend-dependency, ask the user if he wants to replace that zend-dependency the laminas pendant, write the dependency to `composer.json` of the project and remember that we introduced that dependency due to a non-migrated library.


### TL;DR
This is finally ready for review.


### Story on why I decided to go this way

After many sleepless nights and a total rewrite of the dependency plugin, I realized that this approach would probably be a future proof solution but its way too complex.
The complexity exceeded my brain capacity too often.
Its unmaintainable due to all those possible combinations:
- 3rd-party library no.1 uses zend-dependency and is required via root `composer.json` as a `require` package
- 3rd party library no.2 uses same zend-dependency and is required via root `composer.json` as a `require-dev` package
- 3rd party library no.1 is being uninstalled
- root `composer.json` should change the `require` of the laminas equivalent to `require-dev` as there is only a dev-requirement left which requires the zend-package

And thats just one of those complex scenarios... 

However, after I realized that #15 wont be a solution I am happy with, I started to work on this approach today. I don't know why I tried this earlier (as I was debugging what exactly changed in composer 2.0 that the slip-stream solution we are actually use does not work anymore)... That would probably saved my a ton of work.