### PR TITLE
Fix: DependencyRewriterV1 should implement DependencySolvingCapableInterface

### DIFF
--- a/src/DependencyRewriterV1.php
+++ b/src/DependencyRewriterV1.php
@@ -18,7 +18,7 @@ use function get_class;
 use function in_array;
 use function sprintf;
 
-final class DependencyRewriterV1 extends AbstractDependencyRewriter
+final class DependencyRewriterV1 extends AbstractDependencyRewriter implements DependencySolvingCapableInterface
 {
     /**
      * Replace ZF packages present in the composer.json during install or

--- a/test/DependencyRewriterV1Test.php
+++ b/test/DependencyRewriterV1Test.php
@@ -21,6 +21,7 @@ use Composer\Plugin\PluginInterface;
 use Composer\Plugin\PreCommandRunEvent;
 use Composer\Repository\RepositoryManager;
 use Laminas\DependencyPlugin\DependencyRewriterV1;
+use Laminas\DependencyPlugin\DependencySolvingCapableInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -739,5 +740,10 @@ final class DependencyRewriterV1Test extends TestCase
 
         $this->assertNull($this->plugin->onPrePackageInstallOrUpdate($event->reveal()));
         $this->assertSame($replacementPackage, $operation->getTargetPackage());
+    }
+
+    public function testRewriterImplementsDependencySolvingCapableInterface() : void
+    {
+        self::assertInstanceOf(DependencySolvingCapableInterface::class, $this->plugin);
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

`DependencyRewriterV1` currently implements the required method of `DependencySolvingCapableInterface` but the class itself doesn't say that in its signature, so the [Assertion in the plugin](https://github.com/rieschl/laminas-dependency-plugin/blob/809f8e164d388b79d0c3f2228a3bdf448be6bfa8/src/DependencyRewriterPluginDelegator.php#L68) fails.
This PR fixes that.


fixes #23 