### PR TITLE
Add support for PHP 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 /vendor/
 /laminas-mkdoc-theme.tgz
 /laminas-mkdoc-theme/
+/.phpcs-cache
 /.phpunit.result.cache
 /composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,47 +7,32 @@ cache:
 env:
   global:
     - COMPOSER_VERSION="1"
-    - COMPAT=false
     - TEST=false
     - CS_CHECK=false
-    - COMPOSER_ARGS="--no-interaction"
-    - TEST_DEPS="phpunit/phpunit:^9.1 phpspec/prophecy-phpunit webimpress/coding-standard:^1.0"
+    - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
+    - TEST_DEPS="phpunit/phpunit:^9.3 laminas/laminas-coding-standard:~2.1.0"
 
 matrix:
   include:
-    - php: 5.6
-    - php: 5.6
-      env:
-        - COMPOSER_VERSION=2
-    - php: 7.0
-    - php: 7.0
-      env:
-        - COMPOSER_VERSION=2
-    - php: 7.1
-    - php: 7.1
-      env:
-        - COMPOSER_VERSION=2
-    - php: 7.2
-    - php: 7.2
-      env:
-        - COMPOSER_VERSION=2
-    - php: 7.3
-      env:
-        - COMPOSER_VERSION=2
     - php: 7.3
       env:
         - TEST=true
         - CS_CHECK=true
+    - php: 7.3
+      env:
+        - COMPOSER_VERSION=2
+    - php: 7.4
+      env:
+        - TEST_COVERAGE=true
     - php: 7.4
       env:
         - COMPOSER_VERSION=2
         - TEST_COVERAGE=true
-    - php: 7.4
-      env:
-        - TEST_COVERAGE=true
-        - COMPAT=true
-  allow_failures:
     - php: nightly
+      env:
+    - php: nightly
+      env:
+        - COMPOSER_VERSION=2
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
@@ -61,7 +46,6 @@ install:
 
 script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then composer test-coverage ; else if [[ $TEST != 'false' ]]; then  composer test ; fi ; fi
-  - if [[ "$COMPAT" == 'true' ]]; then composer compat ; fi
   - if [[ $CS_CHECK == 'true' ]]; then composer cs-check ; fi
 
 after_success:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- [#25](https://github.com/laminas/laminas-dependency-plugin/pull/25) adds support for PHP 8.
 
 ### Changed
 
@@ -18,7 +18,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Removed
 
-- Nothing.
+- [#25](https://github.com/laminas/laminas-dependency-plugin/pull/25) removes support for PHP versions prior to 7.3.
 
 ### Fixed
 

--- a/composer.json
+++ b/composer.json
@@ -7,13 +7,12 @@
         "sort-packages": true
     },
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.3 || ~8.0.0",
         "composer-plugin-api": "^1.1 || ^2.0"
     },
     "require-dev": {
         "composer/composer": "^1.9 || ^2.0",
         "mikey179/vfsstream": "^1.6",
-        "phpcompatibility/php-compatibility": "^9.3",
         "roave/security-advisories": "dev-master"
     },
     "autoload": {
@@ -39,9 +38,6 @@
         "cs-check": "phpcs",
         "cs-fix": "phpcbf",
         "test": "phpunit --colors=always",
-        "test-coverage": "phpunit --colors=always --coverage-clover clover.xml",
-        "post-install-cmd": "phpcs --config-set installed_paths vendor/phpcompatibility/php-compatibility",
-        "post-update-cmd" : "phpcs --config-set installed_paths vendor/phpcompatibility/php-compatibility",
-        "compat": "phpcs --standard=PHPCompatibility src/ -- --runtime-set testVersion 5.6-"
+        "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
     }
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,18 +1,24 @@
 <?xml version="1.0"?>
-<ruleset name="Webimpress Coding Standard">
-    <rule ref="./vendor/webimpress/coding-standard/ruleset.xml">
-        <exclude name="WebimpressCodingStandard.Functions.NullableTypehint"/>
-    </rule>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="./vendor/squizlabs/php_codesniffer/phpcs.xsd">
+
+    <arg name="basepath" value="." />
+    <arg name="cache" value=".phpcs-cache" />
+    <arg name="colors" />
+    <arg name="extensions" value="php" />
+    <arg name="parallel" value="80" />
+
+    <!-- Show progress -->
+    <arg value="p"/>
 
     <!-- Paths to check -->
     <file>src</file>
     <file>test</file>
 
-    <rule ref="WebimpressCodingStandard.PHP.DeclareStrictTypes">
-        <exclude-pattern>src/*</exclude-pattern>
-    </rule>
+    <!-- Include all rules from Laminas Coding Standard -->
+    <rule ref="LaminasCodingStandard" />
 
-    <rule ref="Generic.NamingConventions.CamelCapsFunctionName">
-        <exclude-pattern>test/*</exclude-pattern>
+    <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements.UnusedMethod">
+        <exclude-pattern>/src/AbstractDependencyRewriter.php</exclude-pattern>
     </rule>
 </ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,17 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         colors="true">
-    <testsuites>
-        <testsuite name="laminas-dependency-plugin">
-            <directory>./test</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="laminas-dependency-plugin">
+      <directory>./test</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/AbstractDependencyRewriter.php
+++ b/src/AbstractDependencyRewriter.php
@@ -15,7 +15,6 @@ use Composer\Plugin\PreCommandRunEvent;
 
 use function array_map;
 use function array_shift;
-use function get_class;
 use function in_array;
 use function preg_split;
 use function reset;
@@ -29,9 +28,7 @@ abstract class AbstractDependencyRewriter implements RewriterInterface
     /** @var IOInterface */
     protected $io;
 
-    /**
-     * @var Replacements
-     */
+    /** @var Replacements */
     private $replacements;
 
     public function __construct()
@@ -42,8 +39,8 @@ abstract class AbstractDependencyRewriter implements RewriterInterface
     public function activate(Composer $composer, IOInterface $io)
     {
         $this->composer = $composer;
-        $this->io = $io;
-        $this->output(sprintf('<info>Activating %s</info>', get_class($this)), IOInterface::DEBUG);
+        $this->io       = $io;
+        $this->output(sprintf('<info>Activating %s</info>', static::class), IOInterface::DEBUG);
     }
 
     /**
@@ -59,7 +56,7 @@ abstract class AbstractDependencyRewriter implements RewriterInterface
         $this->output(
             sprintf(
                 '<info>In %s::%s</info>',
-                get_class($this),
+                static::class,
                 __FUNCTION__
             ),
             IOInterface::DEBUG

--- a/src/DependencyRewriterPluginDelegator.php
+++ b/src/DependencyRewriterPluginDelegator.php
@@ -27,12 +27,10 @@ use function version_compare;
 
 class DependencyRewriterPluginDelegator implements EventSubscriberInterface, PluginInterface
 {
-    /**
-     * @var RewriterInterface
-     */
+    /** @var RewriterInterface */
     private $rewriter;
 
-    public function __construct(RewriterInterface $rewriter = null)
+    public function __construct(?RewriterInterface $rewriter = null)
     {
         $this->rewriter = $rewriter
             ?: $this->createDependencyRewriterForPluginVersion(PluginInterface::PLUGIN_API_VERSION);
@@ -47,18 +45,18 @@ class DependencyRewriterPluginDelegator implements EventSubscriberInterface, Plu
         if (version_compare(PluginInterface::PLUGIN_API_VERSION, '2.0', 'lt')) {
             return [
                 InstallerEvents::PRE_DEPENDENCIES_SOLVING => ['onPreDependenciesSolving', 1000],
-                PackageEvents::PRE_PACKAGE_INSTALL => ['onPrePackageInstallOrUpdate', 1000],
-                PackageEvents::PRE_PACKAGE_UPDATE => ['onPrePackageInstallOrUpdate', 1000],
-                PluginEvents::PRE_COMMAND_RUN => ['onPreCommandRun', 1000],
+                PackageEvents::PRE_PACKAGE_INSTALL        => ['onPrePackageInstallOrUpdate', 1000],
+                PackageEvents::PRE_PACKAGE_UPDATE         => ['onPrePackageInstallOrUpdate', 1000],
+                PluginEvents::PRE_COMMAND_RUN             => ['onPreCommandRun', 1000],
             ];
         }
 
         return [
-            PluginEvents::PRE_POOL_CREATE => ['onPrePoolCreate', 1000],
+            PluginEvents::PRE_POOL_CREATE      => ['onPrePoolCreate', 1000],
             PackageEvents::PRE_PACKAGE_INSTALL => ['onPrePackageInstallOrUpdate', 1000],
-            PackageEvents::PRE_PACKAGE_UPDATE => ['onPrePackageInstallOrUpdate', 1000],
-            PluginEvents::PRE_COMMAND_RUN => ['onPreCommandRun', 1000],
-            ScriptEvents::POST_AUTOLOAD_DUMP => ['onPostAutoloadDump', -1000],
+            PackageEvents::PRE_PACKAGE_UPDATE  => ['onPrePackageInstallOrUpdate', 1000],
+            PluginEvents::PRE_COMMAND_RUN      => ['onPreCommandRun', 1000],
+            ScriptEvents::POST_AUTOLOAD_DUMP   => ['onPostAutoloadDump', -1000],
         ];
     }
 

--- a/src/DependencyRewriterV1.php
+++ b/src/DependencyRewriterV1.php
@@ -33,7 +33,7 @@ final class DependencyRewriterV1 extends AbstractDependencyRewriter implements D
     {
         $this->output(sprintf('<info>In %s</info>', __METHOD__), IOInterface::DEBUG);
         $request = $event->getRequest();
-        $jobs = $request->getJobs();
+        $jobs    = $request->getJobs();
         $changes = false;
 
         foreach ($jobs as $index => $job) {
@@ -62,8 +62,8 @@ final class DependencyRewriterV1 extends AbstractDependencyRewriter implements D
             ), IOInterface::VERBOSE);
 
             $job['packageName'] = $replacementName;
-            $jobs[$index] = $job;
-            $changes = true;
+            $jobs[$index]       = $job;
+            $changes            = true;
         }
 
         if (! $changes) {
@@ -121,7 +121,7 @@ final class DependencyRewriterV1 extends AbstractDependencyRewriter implements D
             return;
         }
 
-        $version = $package->getVersion();
+        $version            = $package->getVersion();
         $replacementPackage = $this->composer->getRepositoryManager()->findPackage($replacementName, $version);
 
         if ($replacementPackage === null) {

--- a/test/DependencyRewriterPluginDelegatorTest.php
+++ b/test/DependencyRewriterPluginDelegatorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @see       https://github.com/laminas/laminas-dependency-plugin for the canonical source repository
  * @copyright https://github.com/laminas/laminas-dependency-plugin/blob/master/COPYRIGHT.md
@@ -27,12 +28,12 @@ use PHPUnit\Framework\TestCase;
 
 final class DependencyRewriterPluginDelegatorTest extends TestCase
 {
-    public function testWillTriggerActivate() : void
+    public function testWillTriggerActivate(): void
     {
         $composer = $this->createMock(Composer::class);
-        $io = $this->createMock(IOInterface::class);
+        $io       = $this->createMock(IOInterface::class);
 
-        $rewriter = $this->createMock(AbstractDependencyRewriter::class);
+        $rewriter  = $this->createMock(AbstractDependencyRewriter::class);
         $delegator = new DependencyRewriterPluginDelegator($rewriter);
         $rewriter
             ->expects($this->once())
@@ -44,12 +45,11 @@ final class DependencyRewriterPluginDelegatorTest extends TestCase
 
     /**
      * @dataProvider eventsToForward
-     *
      * @param string $event
      */
-    public function testWillForwardEvents(string $rewriter, string $eventMethod, $event) : void
+    public function testWillForwardEvents(string $rewriter, string $eventMethod, $event): void
     {
-        $event = $this->createMock($event);
+        $event    = $this->createMock($event);
         $rewriter = $this->createMock($rewriter);
         $rewriter
             ->expects($this->once())
@@ -62,7 +62,7 @@ final class DependencyRewriterPluginDelegatorTest extends TestCase
         $delegator->$eventMethod($event);
     }
 
-    public function eventsToForward() : Generator
+    public function eventsToForward(): Generator
     {
         yield 'onPreDependenciesSolving' => [
             DependencySolvingCapableInterface::class,

--- a/test/ReplacementsTest.php
+++ b/test/ReplacementsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @see       https://github.com/laminas/laminas-dependency-plugin for the canonical source repository
  * @copyright https://github.com/laminas/laminas-dependency-plugin/blob/master/COPYRIGHT.md
@@ -15,12 +16,10 @@ use PHPUnit\Framework\TestCase;
 
 final class ReplacementsTest extends TestCase
 {
-    /**
-     * @var Replacements
-     */
+    /** @var Replacements */
     private $replacements;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->replacements = new Replacements();
@@ -31,13 +30,13 @@ final class ReplacementsTest extends TestCase
      * @dataProvider ignoredZFCampusPackages
      * @dataProvider zendToLaminasPackageNames
      */
-    public function testWillReplacePackageNames(string $packageName, string $expectedPackageName) : void
+    public function testWillReplacePackageNames(string $packageName, string $expectedPackageName): void
     {
         $transformedPackageName = $this->replacements->transformPackageName($packageName);
         $this->assertEquals($expectedPackageName, $transformedPackageName);
     }
 
-    public function zendToLaminasPackageNames() : Generator
+    public function zendToLaminasPackageNames(): Generator
     {
         yield 'zendframework/zenddiagnostics' => ['zendframework/zenddiagnostics', 'laminas/laminas-diagnostics'];
         yield 'zendframework/zendoauth' => ['zendframework/zendoauth', 'laminas/laminas-oauth'];
@@ -84,7 +83,7 @@ final class ReplacementsTest extends TestCase
         yield 'zendframework/zend-* regex' => ['zendframework/zend-config', 'laminas/laminas-config'];
     }
 
-    public function ignoredZendPackages() : Generator
+    public function ignoredZendPackages(): Generator
     {
         yield 'ignored zend-debug' => ['zendframework/zend-debug', 'zendframework/zend-debug'];
         yield 'ignored zend-version' => ['zendframework/zend-version', 'zendframework/zend-version'];
@@ -98,7 +97,7 @@ final class ReplacementsTest extends TestCase
         ];
     }
 
-    public function ignoredZFCampusPackages() : Generator
+    public function ignoredZFCampusPackages(): Generator
     {
         yield 'ignored zf-apigility-example' => ['zfcampus/zf-apigility-example', 'zfcampus/zf-apigility-example'];
         yield 'ignored zf-angular' => ['zfcampus/zf-angular', 'zfcampus/zf-angular'];


### PR DESCRIPTION
Includes:

- Updating PHP constraints to `^7.3 || ~8.0.0`.
- Rewriting mocks from Prophecy to PHPUnit mock objects.
- Updating phpcs configuration to use laminas-coding-standard ~2.1.0, and fixing all flagged errors.
- Removing phpcompat from the list of dev requirements.

Fixes #20 