### PR TITLE
Add psalm integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ env:
     - TEST=false
     - CS_CHECK=false
     - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
-    - TEST_DEPS="phpunit/phpunit:^9.3 laminas/laminas-coding-standard:~2.1.0 vimeo/psalm psalm/plugin-phpunit"
+    - TEST_DEPS="phpunit/phpunit:^9.3 laminas/laminas-coding-standard:~2.1.0"
+    - STATIC_ANALYSIS_DEPS="vimeo/psalm psalm/plugin-phpunit"
 
 matrix:
   include:
@@ -28,6 +29,7 @@ matrix:
       env:
         - COMPOSER_VERSION=2
         - TEST_COVERAGE=true
+        - STATIC_ANALYSIS=true
     - php: nightly
       env:
     - php: nightly
@@ -42,12 +44,13 @@ install:
   - if [[ $COMPOSER_VERSION == "1" ]]; then travis_retry composer update composer/* --prefer-lowest ; fi
   - if [[ $TEST == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $TEST_DEPS ; fi
   - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $TEST_DEPS ; fi
+  - if [[ $STATIC_ANALYSIS == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $STATIC_ANALYSIS_DEPS ; fi
   - stty cols 120 && composer show
 
 script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then composer test-coverage ; else if [[ $TEST != 'false' ]]; then  composer test ; fi ; fi
   - if [[ $CS_CHECK == 'true' ]]; then composer cs-check ; fi
-  - if [[ $TEST_COVERAGE == 'true' ]]; then composer static-analysis ; fi
+  - if [[ $STATIC_ANALYSIS == 'true' ]]; then composer static-analysis ; fi
 
 after_success:
   - bash <(curl -s https://codecov.io/bash) -cF composer${COMPOSER_VERSION}

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
     - TEST=false
     - CS_CHECK=false
     - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
-    - TEST_DEPS="phpunit/phpunit:^9.3 laminas/laminas-coding-standard:~2.1.0"
+    - TEST_DEPS="phpunit/phpunit:^9.3 laminas/laminas-coding-standard:~2.1.0 vimeo/psalm psalm/plugin-phpunit"
 
 matrix:
   include:
@@ -47,6 +47,7 @@ install:
 script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then composer test-coverage ; else if [[ $TEST != 'false' ]]; then  composer test ; fi ; fi
   - if [[ $CS_CHECK == 'true' ]]; then composer cs-check ; fi
+  - if [[ $TEST_COVERAGE == 'true' ]]; then composer static-analysis ; fi
 
 after_success:
   - bash <(curl -s https://codecov.io/bash) -cF composer${COMPOSER_VERSION}

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
         ],
         "cs-check": "phpcs",
         "cs-fix": "phpcbf",
+        "static-analysis": "psalm --shepherd --stats",
         "test": "phpunit --colors=always",
         "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
     }

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<psalm
+    totallyTyped="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+>
+    <projectFiles>
+        <directory name="src"/>
+        <directory name="test"/>
+        <ignoreFiles>
+            <directory name="vendor"/>
+            <file name="test/DependencyRewriterV1Test.php"/>
+        </ignoreFiles>
+    </projectFiles>
+
+    <issueHandlers>
+        <InternalMethod>
+            <errorLevel type="suppress">
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::method"/>
+            </errorLevel>
+            <errorLevel type="suppress">
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::willReturn"/>
+            </errorLevel>
+            <errorLevel type="suppress">
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::with"/>
+            </errorLevel>
+        </InternalMethod>
+    </issueHandlers>
+    <plugins>
+        <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
+    </plugins>
+</psalm>

--- a/src/AbstractDependencyRewriter.php
+++ b/src/AbstractDependencyRewriter.php
@@ -16,16 +16,24 @@ use Composer\Plugin\PreCommandRunEvent;
 use function array_map;
 use function array_shift;
 use function in_array;
+use function is_array;
 use function preg_split;
 use function reset;
 use function sprintf;
 
+/** @psalm-suppress PropertyNotSetInConstructor */
 abstract class AbstractDependencyRewriter implements RewriterInterface
 {
-    /** @var Composer */
+    /**
+     * @psalm-suppress PropertyNotSetInConstructor
+     * @var Composer
+     */
     protected $composer;
 
-    /** @var IOInterface */
+    /**
+     * @psalm-suppress PropertyNotSetInConstructor
+     * @var IOInterface
+     */
     protected $io;
 
     /** @var Replacements */
@@ -36,6 +44,9 @@ abstract class AbstractDependencyRewriter implements RewriterInterface
         $this->replacements = new Replacements();
     }
 
+    /**
+     * @return void
+     */
     public function activate(Composer $composer, IOInterface $io)
     {
         $this->composer = $composer;
@@ -50,6 +61,8 @@ abstract class AbstractDependencyRewriter implements RewriterInterface
      * this listener will replace the argument with the equivalent Laminas
      * package. This ensures that the `composer.json` file is written to
      * reflect the package installed.
+     *
+     * @return void
      */
     public function onPreCommandRun(PreCommandRunEvent $event)
     {
@@ -72,9 +85,10 @@ abstract class AbstractDependencyRewriter implements RewriterInterface
             return;
         }
 
+        $packages = $input->getArgument('packages');
         $input->setArgument(
             'packages',
-            array_map([$this, 'updatePackageArgument'], $input->getArgument('packages'))
+            is_array($packages) ? array_map([$this, 'updatePackageArgument'], $packages) : []
         );
     }
 
@@ -84,7 +98,7 @@ abstract class AbstractDependencyRewriter implements RewriterInterface
      * @param string $message
      * @param int $verbosity
      */
-    protected function output($message, $verbosity = IOInterface::NORMAL)
+    protected function output($message, $verbosity = IOInterface::NORMAL): void
     {
         $this->io->write($message, true, $verbosity);
     }

--- a/src/AutoloadDumpCapableInterface.php
+++ b/src/AutoloadDumpCapableInterface.php
@@ -12,5 +12,8 @@ use Composer\Script\Event;
 
 interface AutoloadDumpCapableInterface extends RewriterInterface
 {
+    /**
+     * @return void
+     */
     public function onPostAutoloadDump(Event $event);
 }

--- a/src/DependencyRewriterPluginDelegator.php
+++ b/src/DependencyRewriterPluginDelegator.php
@@ -43,6 +43,7 @@ class DependencyRewriterPluginDelegator implements EventSubscriberInterface, Plu
     public static function getSubscribedEvents()
     {
         if (version_compare(PluginInterface::PLUGIN_API_VERSION, '2.0', 'lt')) {
+            /** @psalm-suppress UndefinedConstant */
             return [
                 InstallerEvents::PRE_DEPENDENCIES_SOLVING => ['onPreDependenciesSolving', 1000],
                 PackageEvents::PRE_PACKAGE_INSTALL        => ['onPrePackageInstallOrUpdate', 1000],
@@ -60,6 +61,9 @@ class DependencyRewriterPluginDelegator implements EventSubscriberInterface, Plu
         ];
     }
 
+    /**
+     * @return void
+     */
     public function onPreDependenciesSolving(InstallerEvent $event)
     {
         $rewriter = $this->rewriter;
@@ -67,16 +71,25 @@ class DependencyRewriterPluginDelegator implements EventSubscriberInterface, Plu
         $rewriter->onPreDependenciesSolving($event);
     }
 
+    /**
+     * @return void
+     */
     public function onPrePackageInstallOrUpdate(PackageEvent $event)
     {
         $this->rewriter->onPrePackageInstallOrUpdate($event);
     }
 
+    /**
+     * @return void
+     */
     public function onPreCommandRun(PreCommandRunEvent $event)
     {
         $this->rewriter->onPreCommandRun($event);
     }
 
+    /**
+     * @return void
+     */
     public function onPrePoolCreate(PrePoolCreateEvent $event)
     {
         $rewriter = $this->rewriter;
@@ -84,6 +97,9 @@ class DependencyRewriterPluginDelegator implements EventSubscriberInterface, Plu
         $rewriter->onPrePoolCreate($event);
     }
 
+    /**
+     * @return void
+     */
     public function onPostAutoloadDump(Event $event)
     {
         $rewriter = $this->rewriter;
@@ -91,15 +107,24 @@ class DependencyRewriterPluginDelegator implements EventSubscriberInterface, Plu
         $rewriter->onPostAutoloadDump($event);
     }
 
+    /**
+     * @return void
+     */
     public function activate(Composer $composer, IOInterface $io)
     {
         $this->rewriter->activate($composer, $io);
     }
 
+    /**
+     * @return void
+     */
     public function deactivate(Composer $composer, IOInterface $io)
     {
     }
 
+    /**
+     * @return void
+     */
     public function uninstall(Composer $composer, IOInterface $io)
     {
     }

--- a/src/DependencyRewriterV1.php
+++ b/src/DependencyRewriterV1.php
@@ -157,8 +157,10 @@ final class DependencyRewriterV1 extends AbstractDependencyRewriter implements D
         $this->replacePackageInOperation($replacementPackage, $operation);
     }
 
-    private function replacePackageInOperation(PackageInterface $replacement, Operation\OperationInterface $operation): void
-    {
+    private function replacePackageInOperation(
+        PackageInterface $replacement,
+        Operation\OperationInterface $operation
+    ): void {
         $this->updateProperty(
             $operation,
             $operation instanceof Operation\UpdateOperation ? 'targetPackage' : 'package',

--- a/src/DependencySolvingCapableInterface.php
+++ b/src/DependencySolvingCapableInterface.php
@@ -14,6 +14,8 @@ interface DependencySolvingCapableInterface extends RewriterInterface
 {
     /**
      * If a ZF package is being installed, modify the incoming request to slip-stream laminas packages.
+     *
+     * @return void
      */
     public function onPreDependenciesSolving(InstallerEvent $event);
 }

--- a/src/PoolCapableInterface.php
+++ b/src/PoolCapableInterface.php
@@ -14,6 +14,8 @@ interface PoolCapableInterface extends RewriterInterface
 {
     /**
      * If a ZF package is being installed, ensure the pool is modified to install the laminas equivalent instead.
+     *
+     * @return void
      */
     public function onPrePoolCreate(PrePoolCreateEvent $event);
 }

--- a/src/Replacements.php
+++ b/src/Replacements.php
@@ -35,6 +35,7 @@ final class Replacements
         switch ($name) {
             // Packages without replacements:
             case in_array($name, $this->ignore, true):
+                /** @psalm-suppress MixedReturnStatement */
                 return $name;
             // Packages with non-standard naming:
             case 'zendframework/zenddiagnostics':

--- a/src/RewriterInterface.php
+++ b/src/RewriterInterface.php
@@ -15,6 +15,9 @@ use Composer\Plugin\PreCommandRunEvent;
 
 interface RewriterInterface
 {
+    /**
+     * @return void
+     */
     public function activate(Composer $composer, IOInterface $io);
 
     /**
@@ -24,11 +27,15 @@ interface RewriterInterface
      * this listener will replace the argument with the equivalent Laminas
      * package. This ensures that the `composer.json` file is written to
      * reflect the package installed.
+     *
+     * @return void
      */
     public function onPreCommandRun(PreCommandRunEvent $event);
 
     /**
      * When a ZF package is installed or updated, ensure that its being replaced after installation/update is finished.
+     *
+     * @return void
      */
     public function onPrePackageInstallOrUpdate(PackageEvent $event);
 }

--- a/test/DependencyRewriterPluginDelegatorTest.php
+++ b/test/DependencyRewriterPluginDelegatorTest.php
@@ -17,7 +17,6 @@ use Composer\IO\IOInterface;
 use Composer\Plugin\PreCommandRunEvent;
 use Composer\Plugin\PrePoolCreateEvent;
 use Composer\Script\Event;
-use Generator;
 use Laminas\DependencyPlugin\AbstractDependencyRewriter;
 use Laminas\DependencyPlugin\AutoloadDumpCapableInterface;
 use Laminas\DependencyPlugin\DependencyRewriterPluginDelegator;
@@ -45,9 +44,10 @@ final class DependencyRewriterPluginDelegatorTest extends TestCase
 
     /**
      * @dataProvider eventsToForward
-     * @param string $event
+     * @psalm-param class-string $rewriter
+     * @psalm-param class-string $event
      */
-    public function testWillForwardEvents(string $rewriter, string $eventMethod, $event): void
+    public function testWillForwardEvents(string $rewriter, string $eventMethod, string $event): void
     {
         $event    = $this->createMock($event);
         $rewriter = $this->createMock($rewriter);
@@ -62,7 +62,10 @@ final class DependencyRewriterPluginDelegatorTest extends TestCase
         $delegator->$eventMethod($event);
     }
 
-    public function eventsToForward(): Generator
+    /**
+     * @psalm-return iterable<array-key, array{0: class-string, 1: string, 2: class-string}>
+     */
+    public function eventsToForward(): iterable
     {
         yield 'onPreDependenciesSolving' => [
             DependencySolvingCapableInterface::class,

--- a/test/ReplacementsTest.php
+++ b/test/ReplacementsTest.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 
 namespace LaminasTest\DependencyPlugin;
 
-use Generator;
 use Laminas\DependencyPlugin\Replacements;
 use PHPUnit\Framework\TestCase;
 
@@ -36,7 +35,10 @@ final class ReplacementsTest extends TestCase
         $this->assertEquals($expectedPackageName, $transformedPackageName);
     }
 
-    public function zendToLaminasPackageNames(): Generator
+    /**
+     * @psalm-return iterable<array-key, array{0: string, 1: string}>
+     */
+    public function zendToLaminasPackageNames(): iterable
     {
         yield 'zendframework/zenddiagnostics' => ['zendframework/zenddiagnostics', 'laminas/laminas-diagnostics'];
         yield 'zendframework/zendoauth' => ['zendframework/zendoauth', 'laminas/laminas-oauth'];
@@ -83,7 +85,10 @@ final class ReplacementsTest extends TestCase
         yield 'zendframework/zend-* regex' => ['zendframework/zend-config', 'laminas/laminas-config'];
     }
 
-    public function ignoredZendPackages(): Generator
+    /**
+     * @psalm-return iterable<array-key, array{0: string, 1: string}>
+     */
+    public function ignoredZendPackages(): iterable
     {
         yield 'ignored zend-debug' => ['zendframework/zend-debug', 'zendframework/zend-debug'];
         yield 'ignored zend-version' => ['zendframework/zend-version', 'zendframework/zend-version'];
@@ -97,7 +102,10 @@ final class ReplacementsTest extends TestCase
         ];
     }
 
-    public function ignoredZFCampusPackages(): Generator
+    /**
+     * @psalm-return iterable<array-key, array{0: string, 1: string}>
+     */
+    public function ignoredZFCampusPackages(): iterable
     {
         yield 'ignored zf-apigility-example' => ['zfcampus/zf-apigility-example', 'zfcampus/zf-apigility-example'];
         yield 'ignored zf-angular' => ['zfcampus/zf-angular', 'zfcampus/zf-angular'];

--- a/test/TestAsset/IOWriteExpectations.php
+++ b/test/TestAsset/IOWriteExpectations.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-dependency-plugin for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-dependency-plugin/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-dependency-plugin/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace LaminasTest\DependencyPlugin\TestAsset;
+
+use ArrayIterator;
+use IteratorAggregate;
+use Traversable;
+
+use function array_keys;
+use function array_reduce;
+use function implode;
+use function sprintf;
+use function strpos;
+
+class IOWriteExpectations implements IteratorAggregate
+{
+    /**
+     * @var array
+     * @psalm-var array<string, bool>
+     */
+    private $messages = [];
+
+    /**
+     * @param string[] $messages
+     * @psalm-param array<array-key, string> $messages
+     */
+    public function __construct(array $messages)
+    {
+        foreach ($messages as $message) {
+            $this->messages[$message] = false;
+        }
+    }
+
+    public function __toString(): string
+    {
+        $unseenMessages = [];
+        foreach ($this->messages as $message => $seen) {
+            if ($seen) {
+                continue;
+            }
+            $unseenMessages[] = sprintf('- %s', $message);
+        }
+
+        return implode("\n", $unseenMessages);
+    }
+
+    /**
+     * @psalm-return Traversable<array-key, string>
+     */
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator(array_keys($this->messages));
+    }
+
+    public function matches(string $message): bool
+    {
+        foreach ($this as $expectedMessage) {
+            if (false !== strpos($message, $expectedMessage)) {
+                $this->messages[$expectedMessage] = true;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function foundAll(): bool
+    {
+        return array_reduce($this->messages, function (bool $found, bool $flag): bool {
+            return $found && $flag;
+        }, true);
+    }
+}


### PR DESCRIPTION
- Creates a psalm.xml.dist for the package.
- Adds a `static-analysis` script to `composer.json`.
- Updates Travis configuration:
  - Install `vimeo/psalm` and `psalm/phpunit-plugin` when installing test deps.
  - Run static-analysis script when TEST_COVERAGE env is present.
- Fixes all errors flagged by psalm.
  - Extracts anonymous class to a test asset, and uses proper type hinting against it in test cases.

Fixes #19
