### PR TITLE
bugfix: use proper methods to receive input option informations

### DIFF
--- a/test/DependencyRewriterV2Test.php
+++ b/test/DependencyRewriterV2Test.php
@@ -970,26 +970,27 @@ final class DependencyRewriterV2Test extends TestCase
         $consecutiveGetOptionReturnValues = [];
 
         foreach (DependencyRewriterV2::COMPOSER_LOCK_UPDATE_OPTIONS as $optionName) {
-            $consecutiveHasOptionArguments[]    = [$optionName];
+            $option                             = sprintf('--%s', $optionName);
+            $consecutiveHasOptionArguments[]    = [$option, true];
             $passed                             = array_key_exists($optionName, $optionsPassedToComposer);
             $consecutiveHasOptionReturnValues[] = $passed;
             if (! $passed) {
                 continue;
             }
 
-            $consecutiveGetOptionArguments[]    = [$optionName];
+            $consecutiveGetOptionArguments[]    = [$option, false, true];
             $consecutiveGetOptionReturnValues[] = $optionsPassedToComposer[$optionName];
         }
 
         $input
             ->expects(self::exactly(count(DependencyRewriterV2::COMPOSER_LOCK_UPDATE_OPTIONS)))
-            ->method('hasOption')
+            ->method('hasParameterOption')
             ->withConsecutive(...$consecutiveHasOptionArguments)
             ->willReturnOnConsecutiveCalls(...$consecutiveHasOptionReturnValues);
 
         $input
             ->expects(self::exactly(count($consecutiveGetOptionArguments)))
-            ->method('getOption')
+            ->method('getParameterOption')
             ->withConsecutive(...$consecutiveGetOptionArguments)
             ->willReturnOnConsecutiveCalls(...$consecutiveGetOptionReturnValues);
 


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

With #29, `InputInterface::hasOption` and `InputInterface::getOption` were introduced. It seems that these methods only work if you pass an `InputDefinition`.
Thus, we have to use `InputInterface::hasParameterOption` along with `InputInterface::getParameterOption`.