### PR TITLE
Apply PHP 7.4 syntax and typed property

### DIFF
--- a/src/AbstractDependencyRewriter.php
+++ b/src/AbstractDependencyRewriter.php
@@ -8,6 +8,7 @@ use Composer\Composer;
 use Composer\Installer\PackageEvent;
 use Composer\IO\IOInterface;
 use Composer\Plugin\PreCommandRunEvent;
+use Laminas\DependencyPlugin\Replacements;
 
 use function array_map;
 use function array_shift;
@@ -32,8 +33,7 @@ abstract class AbstractDependencyRewriter implements RewriterInterface
      */
     protected $io;
 
-    /** @var Replacements */
-    private $replacements;
+    private Replacements $replacements;
 
     public function __construct()
     {
@@ -88,9 +88,7 @@ abstract class AbstractDependencyRewriter implements RewriterInterface
         $packages = is_array($packages) ? $packages : [];
         $packages = array_map(
             /** @param scalar $value */
-            static function ($value): string {
-                return (string) $value;
-            },
+            static fn($value): string => (string) $value,
             $packages
         );
 

--- a/src/DependencyRewriterPluginDelegator.php
+++ b/src/DependencyRewriterPluginDelegator.php
@@ -17,14 +17,14 @@ use Composer\Plugin\PreCommandRunEvent;
 use Composer\Plugin\PrePoolCreateEvent;
 use Composer\Script\Event;
 use Composer\Script\ScriptEvents;
+use Laminas\DependencyPlugin\RewriterInterface;
 
 use function assert;
 use function version_compare;
 
 class DependencyRewriterPluginDelegator implements EventSubscriberInterface, PluginInterface
 {
-    /** @var RewriterInterface */
-    private $rewriter;
+    private RewriterInterface $rewriter;
 
     public function __construct(?RewriterInterface $rewriter = null)
     {

--- a/src/DependencyRewriterV2.php
+++ b/src/DependencyRewriterV2.php
@@ -45,11 +45,9 @@ final class DependencyRewriterV2 extends AbstractDependencyRewriter implements
     /** @var callable */
     private $applicationFactory;
 
-    /** @var string */
-    private $composerFile;
+    private string $composerFile;
 
-    /** @var InputInterface */
-    private $input;
+    private InputInterface $input;
 
     public function __construct(
         ?callable $applicationFactory = null,
@@ -60,9 +58,7 @@ final class DependencyRewriterV2 extends AbstractDependencyRewriter implements
 
         /** @psalm-suppress MixedAssignment */
         $this->composerFile       = $composerFile ?: Factory::getComposerFile();
-        $this->applicationFactory = $applicationFactory ?? static function (): Application {
-            return new Application();
-        };
+        $this->applicationFactory = $applicationFactory ?? static fn(): Application => new Application();
         $this->input              = $input ?? new ArgvInput();
     }
 

--- a/src/Replacements.php
+++ b/src/Replacements.php
@@ -11,7 +11,7 @@ use function sprintf;
 final class Replacements
 {
     /** @var string[] */
-    private $ignore = [
+    private array $ignore = [
         'zendframework/zend-debug',
         'zendframework/zend-version',
         'zendframework/zendservice-apple-apns',

--- a/test/DependencyRewriterV1Test.php
+++ b/test/DependencyRewriterV1Test.php
@@ -42,8 +42,7 @@ final class DependencyRewriterV1Test extends TestCase
      */
     private $io;
 
-    /** @var DependencyRewriterV1 */
-    private $plugin;
+    private DependencyRewriterV1 $plugin;
 
     public function setUp(): void
     {

--- a/test/DependencyRewriterV2Test.php
+++ b/test/DependencyRewriterV2Test.php
@@ -64,8 +64,7 @@ final class DependencyRewriterV2Test extends TestCase
      */
     private $io;
 
-    /** @var DependencyRewriterV2 */
-    private $plugin;
+    private DependencyRewriterV2 $plugin;
 
     /**
      * @var InstallationManager|MockObject
@@ -130,7 +129,7 @@ final class DependencyRewriterV2Test extends TestCase
         $this->io
             ->expects($this->any())
             ->method('write')
-            ->will($this->returnCallback(function (string $message) use ($ioWriteExpectations): void {
+            ->will($this->returnCallback(static function (string $message) use ($ioWriteExpectations): void {
                 if (! $ioWriteExpectations->matches($message)) {
                     throw new InvalidArgumentException('IO::write received unexpected message: ' . $message);
                 }
@@ -451,9 +450,7 @@ final class DependencyRewriterV2Test extends TestCase
             $uninstallExpectations[] = [
                 $this->localRepository,
                 $this->callback(
-                    static function (Operation\UninstallOperation $operation) use ($package): bool {
-                        return $operation->getPackage() === $package;
-                    }
+                    static fn(Operation\UninstallOperation $operation): bool => $operation->getPackage() === $package
                 ),
             ];
         }

--- a/test/ReplacementsTest.php
+++ b/test/ReplacementsTest.php
@@ -9,8 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 final class ReplacementsTest extends TestCase
 {
-    /** @var Replacements */
-    private $replacements;
+    private Replacements $replacements;
 
     protected function setUp(): void
     {

--- a/test/TestAsset/IOWriteExpectations.php
+++ b/test/TestAsset/IOWriteExpectations.php
@@ -16,11 +16,8 @@ use function strpos;
 
 class IOWriteExpectations implements IteratorAggregate
 {
-    /**
-     * @var array
-     * @psalm-var array<string, bool>
-     */
-    private $messages = [];
+    /** @psalm-var array<string, bool> */
+    private array $messages = [];
 
     /**
      * @param string[] $messages
@@ -68,8 +65,6 @@ class IOWriteExpectations implements IteratorAggregate
 
     public function foundAll(): bool
     {
-        return array_reduce($this->messages, function (bool $found, bool $flag): bool {
-            return $found && $flag;
-        }, true);
+        return array_reduce($this->messages, static fn(bool $found, bool $flag): bool => $found && $flag, true);
     }
 }


### PR DESCRIPTION
Signed-off-by: Abdul Malik Ikhsan <samsonasik@gmail.com>

<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

Since composer.json require php 7.4, php 7.4 syntax can be applied with typed properties. 

- For `final class`, typed properties for protected is allowed if no inherit of parent or used by its final class parent.
- Otherwise, update only private properties.

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
